### PR TITLE
Added Support to Specify ClientProvidedName

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -80,8 +80,13 @@ namespace Serilog.Sinks.RabbitMQ
                 Password = _config.Password,
                 AutomaticRecoveryEnabled = true,
                 NetworkRecoveryInterval = TimeSpan.FromSeconds(2),
-                UseBackgroundThreadsForIO = _config.UseBackgroundThreadsForIO
+                UseBackgroundThreadsForIO = _config.UseBackgroundThreadsForIO,
             };
+
+            if (!string.IsNullOrWhiteSpace(_config.ClientProvidedName))
+            {
+                connectionFactory.ClientProvidedName = _config.ClientProvidedName;
+            }
 
             if (_config.SslOption != null)
             {

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -80,7 +80,7 @@ namespace Serilog.Sinks.RabbitMQ
                 Password = _config.Password,
                 AutomaticRecoveryEnabled = true,
                 NetworkRecoveryInterval = TimeSpan.FromSeconds(2),
-                UseBackgroundThreadsForIO = _config.UseBackgroundThreadsForIO,
+                UseBackgroundThreadsForIO = _config.UseBackgroundThreadsForIO
             };
 
             if (!string.IsNullOrWhiteSpace(_config.ClientProvidedName))

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClientConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClientConfiguration.cs
@@ -35,6 +35,7 @@ namespace Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ
         public ushort Heartbeat { get; set; }
         public bool UseBackgroundThreadsForIO { get; set; }
         public SslOption SslOption { get; set; }
+        public string ClientProvidedName { get; set; }
 
         public RabbitMQClientConfiguration From(RabbitMQClientConfiguration config) {
             Username                    = config.Username;
@@ -49,6 +50,7 @@ namespace Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ
             Heartbeat                   = config.Heartbeat;
             UseBackgroundThreadsForIO   = config.UseBackgroundThreadsForIO;
             SslOption                   = config.SslOption;
+            ClientProvidedName          = config.ClientProvidedName;
 
             foreach (string hostName in config.Hostnames)
             {


### PR DESCRIPTION
`ClientProvidedName` is a special field in RabbitMQ.Client to specify a client name to differentiate between connected applications in RabbitMQ Management UI. In this PR, I add support to fill this property.

This is the UI without providing ClientProvidedName (current behavior):

![image](https://user-images.githubusercontent.com/2426207/152817685-b99e8e72-19cf-4fdb-a3a9-350f761f2bc8.png)

This is the UI with providing ClientProvidedName:

![image](https://user-images.githubusercontent.com/2426207/152817830-35d40046-4c08-481d-aebb-ff7ef3c4fd83.png)


Users of the library can specify their ClientProvidedName with configuration:

![image](https://user-images.githubusercontent.com/2426207/152818020-f94566ad-9b40-43a1-8cc1-87f2cd4067e1.png)


If this property is null or whitespace, the library will continue to work as is. So, current users can continue to work without any extra configuration. I mean, there is no breaking change.