### PR TITLE
Exclude sample projects from dotnet pack

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #146  Set IsPackable false for the sample projects