### PR TITLE
Replace Assert statements with Shouldly

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,7 @@ on:
       - '!master'   # excludes master
 
 env:
-  Configuration: Release
+  Configuration: Debug
 
 jobs:
   build:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,7 @@ on:
       - '!master'   # excludes master
 
 env:
-  Configuration: Debug
+  Configuration: Release
 
 jobs:
   build:

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/AuditToRabbitMQSinkAuditTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/AuditToRabbitMQSinkAuditTests.cs
@@ -74,10 +74,10 @@ public sealed class AuditToRabbitMQSinkAuditTests : IClassFixture<RabbitMQFixtur
             });
 
         var receivedMessage = JObject.Parse(Encoding.UTF8.GetString(eventRaised.Arguments.Body.ToArray()));
-        Assert.Equal("Information", receivedMessage["Level"]);
-        Assert.Equal(messageTemplate, receivedMessage["MessageTemplate"]);
-        Assert.NotNull(receivedMessage["Properties"]);
-        Assert.Equal(1.0, receivedMessage["Properties"]!["value"]);
+        receivedMessage["Level"].ShouldBe("Information");
+        receivedMessage["MessageTemplate"].ShouldBe(messageTemplate);
+        receivedMessage["Properties"].ShouldNotBeNull();
+        receivedMessage["Properties"]!["value"].ShouldBe(1.0);
 
         channel.Close();
         logger.Dispose();

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/AuditToRabbitMQSinkAuditTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/AuditToRabbitMQSinkAuditTests.cs
@@ -77,7 +77,7 @@ public sealed class AuditToRabbitMQSinkAuditTests : IClassFixture<RabbitMQFixtur
         receivedMessage["Level"].ShouldBe("Information");
         receivedMessage["MessageTemplate"].ShouldBe(messageTemplate);
         receivedMessage["Properties"].ShouldNotBeNull();
-        receivedMessage["Properties"]!["value"].ShouldBe(1.0);
+        ((double)receivedMessage["Properties"]!["value"]!).ShouldBe(1.0);
 
         channel.Close();
         logger.Dispose();

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTest.cs
@@ -53,7 +53,7 @@ public sealed class RabbitMqClientTest : IClassFixture<RabbitMQFixture>
             });
 
         string receivedMessage = Encoding.UTF8.GetString(eventRaised.Arguments.Body.ToArray());
-        Assert.Equal(message, receivedMessage);
+        receivedMessage.ShouldBe(message);
 
         consumingChannel.Close();
     }
@@ -89,7 +89,7 @@ public sealed class RabbitMqClientTest : IClassFixture<RabbitMQFixture>
             });
 
         string receivedMessage = Encoding.UTF8.GetString(eventRaised.Arguments.Body.ToArray());
-        Assert.Equal(message, receivedMessage);
+        receivedMessage.ShouldBe(message);
 
         consumingChannel.Close();
     }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTest.cs
@@ -80,7 +80,7 @@ public sealed class WriteToRabbitMQSinkTest : IClassFixture<RabbitMQFixture>
             receivedMessage["MessageTemplate"].ShouldBe(messageTemplate);
             receivedMessage["Properties"].ShouldNotBeNull();
             ((double)receivedMessage["Properties"]!["numerator"]!).ShouldBe(1.0);
-            receivedMessage["Properties"]!["denominator"].ShouldBe(0.0);
+            ((double)receivedMessage["Properties"]!["denominator"]!).ShouldBe(0.0);
             receivedMessage["Exception"].ShouldBe("System.DivideByZeroException: Attempted to divide by zero.");
 
             logger.Dispose();

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTest.cs
@@ -79,13 +79,7 @@ public sealed class WriteToRabbitMQSinkTest : IClassFixture<RabbitMQFixture>
             receivedMessage["Level"].ShouldBe("Error");
             receivedMessage["MessageTemplate"].ShouldBe(messageTemplate);
             receivedMessage["Properties"].ShouldNotBeNull();
-            var t = receivedMessage["Properties"]!["numerator"]!;
-            Console.WriteLine(t.GetType());
-            Console.WriteLine(t);
-            var y = 1.0;
-            Console.WriteLine(y.GetType());
-            Console.WriteLine(y);
-            t.ShouldBe(y);
+            ((double)receivedMessage["Properties"]!["numerator"]!).ShouldBe(1.0);
             receivedMessage["Properties"]!["denominator"].ShouldBe(0.0);
             receivedMessage["Exception"].ShouldBe("System.DivideByZeroException: Attempted to divide by zero.");
 

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTest.cs
@@ -76,12 +76,12 @@ public sealed class WriteToRabbitMQSinkTest : IClassFixture<RabbitMQFixture>
         {
             var receivedMessage = JObject.Parse(json);
 
-            Assert.Equal("Error", receivedMessage["Level"]);
-            Assert.Equal(messageTemplate, receivedMessage["MessageTemplate"]);
-            Assert.NotNull(receivedMessage["Properties"]);
-            Assert.Equal(1.0, receivedMessage["Properties"]!["numerator"]);
-            Assert.Equal(0.0, receivedMessage["Properties"]!["denominator"]);
-            Assert.Equal("System.DivideByZeroException: Attempted to divide by zero.", receivedMessage["Exception"]);
+            receivedMessage["Level"].ShouldBe("Error");
+            receivedMessage["MessageTemplate"].ShouldBe(messageTemplate);
+            receivedMessage["Properties"].ShouldNotBeNull();
+            receivedMessage["Properties"]!["numerator"].ShouldBe(1.0);
+            receivedMessage["Properties"]!["denominator"].ShouldBe(0.0);
+            receivedMessage["Exception"].ShouldBe("System.DivideByZeroException: Attempted to divide by zero.");
 
             logger.Dispose();
         }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTest.cs
@@ -79,7 +79,13 @@ public sealed class WriteToRabbitMQSinkTest : IClassFixture<RabbitMQFixture>
             receivedMessage["Level"].ShouldBe("Error");
             receivedMessage["MessageTemplate"].ShouldBe(messageTemplate);
             receivedMessage["Properties"].ShouldNotBeNull();
-            receivedMessage["Properties"]!["numerator"].ShouldBe(1.0);
+            var t = receivedMessage["Properties"]!["numerator"]!;
+            Console.WriteLine(t.GetType());
+            Console.WriteLine(t);
+            var y = 1.0;
+            Console.WriteLine(y.GetType());
+            Console.WriteLine(y);
+            t.ShouldBe(y);
             receivedMessage["Properties"]!["denominator"].ShouldBe(0.0);
             receivedMessage["Exception"].ShouldBe("System.DivideByZeroException: Attempted to divide by zero.");
 


### PR DESCRIPTION
fixes #157 
Current usages:
![изображение](https://github.com/ArieGato/serilog-sinks-rabbitmq/assets/21261007/9f02ac42-ff4c-4c70-b560-2ae7cb28b72b)
 
I don't think it's worth to try change these calls to something else.