### PR TITLE
Target netstandard2.0 only

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
+++ b/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
-    <PackageTags>serilog;logging;rabbitmq;error</PackageTags>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageTags>serilog;logging;rabbitmq</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/ArieGato/serilog-sinks-rabbitmq</PackageProjectUrl>


### PR DESCRIPTION
I suggest to use netstandard2.0 only, at least until someone asks for special need in other tfms. Project has no conditional compilation blocks and all dependencies support netstandard2.0. In fact only few support net6/net8 targets explicitly.