### PR TITLE
Upgrade Serilog to 4.0.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       shell: pwsh
       run: |
-        docker-compose up -d
+        docker compose up -d
         $val = 0
         while(1 -eq 1) {
             $status_ssl_plain = docker inspect --format "{{json .State.Health.Status }}" serilog.sinks.rabbitmq.ssl-plain

--- a/samples/Net8AppsettingsJsonSample/Net8AppsettingsJsonSample.csproj
+++ b/samples/Net8AppsettingsJsonSample/Net8AppsettingsJsonSample.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Net8FromCodeSample/Net8FromCodeSample.csproj
+++ b/samples/Net8FromCodeSample/Net8FromCodeSample.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/NetFrameworkAppSettingsConfigSample/NetFrameworkAppSettingsConfigSample.csproj
+++ b/samples/NetFrameworkAppSettingsConfigSample/NetFrameworkAppSettingsConfigSample.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Settings.AppSettings" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
+++ b/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
@@ -12,12 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" AllowedVersions="[6.8.1,7.0)" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.1.0" />
-    <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Serilog" Version="4.0.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -25,15 +24,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.28" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.33" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.17" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.20" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -18,7 +18,6 @@ using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
-using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.RabbitMQ;
 
@@ -77,7 +76,7 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
     }
 
     /// <inheritdoc cref="IBatchedLogEventSink.EmitBatchAsync" />
-    public Task EmitBatchAsync(IEnumerable<LogEvent> batch)
+    public Task EmitBatchAsync(IReadOnlyCollection<LogEvent> batch)
     {
         // make sure we have an array to avoid multiple enumeration
         var logEvents = batch as LogEvent[] ?? batch.ToArray();

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/Serilog.Sinks.RabbitMQ.Tests.Integration.csproj
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/Serilog.Sinks.RabbitMQ.Tests.Integration.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Settings.AppSettings" Version="3.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,8 +37,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="xunit" Version="2.8.0" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Update="xunit" Version="2.9.1" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
@@ -92,11 +92,11 @@ namespace Serilog.Sinks.RabbitMQ
         NonDurable = 1,
         Durable = 2,
     }
-    public sealed class RabbitMQSink : Serilog.Core.ILogEventSink, Serilog.Sinks.PeriodicBatching.IBatchedLogEventSink, System.IDisposable
+    public sealed class RabbitMQSink : Serilog.Core.IBatchedLogEventSink, Serilog.Core.ILogEventSink, System.IDisposable
     {
         public void Dispose() { }
         public void Emit(Serilog.Events.LogEvent logEvent) { }
-        public System.Threading.Tasks.Task EmitBatchAsync(System.Collections.Generic.IEnumerable<Serilog.Events.LogEvent> batch) { }
+        public System.Threading.Tasks.Task EmitBatchAsync(System.Collections.Generic.IReadOnlyCollection<Serilog.Events.LogEvent> batch) { }
         public System.Threading.Tasks.Task OnEmptyBatchAsync() { }
     }
     public class RabbitMQSinkConfiguration

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -52,7 +52,7 @@ public class RabbitMQSinkTests
     public async Task EmitBatchAsync_ShouldPublishMessages()
     {
         // Arrange
-        IEnumerable<LogEvent> logEvents = [
+        IReadOnlyCollection<LogEvent> logEvents = [
             new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null, new MessageTemplate("some-message-1", []), []),
             new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null, new MessageTemplate("some-message-2", []), [])];
 
@@ -78,7 +78,7 @@ public class RabbitMQSinkTests
     public async Task EmitBatchAsync_ShouldDoNothing_WhenNoEventsAreEmitted()
     {
         // Arrange
-        IEnumerable<LogEvent> logEvents = [];
+        IReadOnlyCollection<LogEvent> logEvents = [];
 
         var textFormatter = Substitute.For<ITextFormatter>();
         var rabbitMQClient = Substitute.For<IRabbitMQClient>();

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/Serilog.Sinks.RabbitMQ.Tests.csproj
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/Serilog.Sinks.RabbitMQ.Tests.csproj
@@ -15,8 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="xunit" Version="2.8.0" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Update="xunit" Version="2.9.1" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
fixes #210

- upgrade Serilog packages
- use new wrapper sink construction
- use IBatchedLogEventSink from core serilog package
- remove Serilog.Sinks.PeriodicBatching dependency
