### PR TITLE
Convert IRabbitMQConnectionFactory to IAsyncDisposable

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/IRabbitMQConnectionFactory.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/IRabbitMQConnectionFactory.cs
@@ -19,7 +19,7 @@ namespace Serilog.Sinks.RabbitMQ;
 /// <summary>
 /// The RabbitMQ connection factory interface.
 /// </summary>
-internal interface IRabbitMQConnectionFactory : IDisposable
+internal interface IRabbitMQConnectionFactory : IAsyncDisposable
 {
     /// <summary>
     /// Returns the connection. Creates a new connection if none exists.

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClient.cs
@@ -123,7 +123,7 @@ internal sealed class RabbitMQClient : IRabbitMQClient
         }
 
         await _channelPool.DisposeAsync().ConfigureAwait(false);
-        _rabbitMQConnectionFactory.Dispose();
+        await _rabbitMQConnectionFactory.DisposeAsync().ConfigureAwait(false);
         _closeTokenSource.Dispose();
     }
 }

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConnectionFactory.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConnectionFactory.cs
@@ -150,16 +150,23 @@ internal sealed class RabbitMQConnectionFactory : IRabbitMQConnectionFactory
     }
 
     /// <inheritdoc />
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         try
         {
-            _connectionLock.Dispose();
-            _connection?.Dispose();
+            if (_connection is not null)
+            {
+                await _connection.CloseAsync().ConfigureAwait(false);
+                _connection.Dispose();
+            }
         }
         catch (Exception exception)
         {
             SelfLog.WriteLine(exception.Message);
+        }
+        finally
+        {
+            _connectionLock.Dispose();
         }
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMQConnectionFactoryTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMQConnectionFactoryTests.cs
@@ -28,7 +28,7 @@ public class RabbitMQConnectionFactoryTests
 
         await sut.CloseAsync();
 
-        sut.Dispose();
+        await sut.DisposeAsync();
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class RabbitMQConnectionFactoryTests
         var rabbitMQClientConfiguration = RabbitMQFixture.GetRabbitMQClientConfiguration();
         rabbitMQClientConfiguration.Port = 5673;
 
-        using var sut = new RabbitMQConnectionFactory(rabbitMQClientConfiguration, new CancellationTokenSource());
+        await using var sut = new RabbitMQConnectionFactory(rabbitMQClientConfiguration, new CancellationTokenSource());
 
         var act = () => sut.GetConnectionAsync();
         (await Should.ThrowAsync<BrokerUnreachableException>(act)).GetType().ShouldBe(typeof(BrokerUnreachableException));
@@ -57,7 +57,7 @@ public class RabbitMQConnectionFactoryTests
 
         await sut.CloseAsync();
 
-        sut.Dispose();
+        await sut.DisposeAsync();
     }
 
     [Fact]
@@ -92,6 +92,6 @@ public class RabbitMQConnectionFactoryTests
         connection.IsOpen.ShouldBeTrue();
 
         await sut.CloseAsync();
-        sut.Dispose();
+        await sut.DisposeAsync();
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQClientTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQClientTests.cs
@@ -141,6 +141,6 @@ public class RabbitMQClientTests
 
         // Assert
         await channelPool.Received(1).DisposeAsync();
-        rabbitMQConnectionFactory.Received(1).Dispose();
+        await rabbitMQConnectionFactory.Received(1).DisposeAsync();
     }
 }


### PR DESCRIPTION
Fixes #276.

## Summary

- `IRabbitMQConnectionFactory` now implements `IAsyncDisposable` (was `IDisposable`), completing the async-disposal refactor started in #274.
- `RabbitMQConnectionFactory.Dispose()` → `DisposeAsync()`. The new method closes the underlying connection gracefully via `CloseAsync` before sync-disposing it, and always releases the `SemaphoreSlim` in a `finally` so a throwing close cannot leak the lock.
- `RabbitMQClient.DisposeAsync` now awaits `_rabbitMQConnectionFactory.DisposeAsync()` instead of calling the old sync `Dispose()`.
- Test substitutes and integration tests updated; `CloseAsync` on the interface is unchanged.

## Notes

- `IRabbitMQConnectionFactory` is `internal`; no change to the public API surface.
- Pre-existing oddities in `RabbitMQConnectionFactory.CloseAsync` (10 ms semaphore timeout, lock not released) are untouched to keep this diff focused — worth a follow-up.

## Test plan

- [x] `dotnet build -c Release` — all TFMs (`netstandard2.0`, `net8.0`, `net10.0`, `net48` for tests).
- [x] Unit tests — 43/43 on net10.0, 42/42 on net8.0.
- [x] Integration tests — 26/26 on net10.0 against the docker-compose brokers.
- [x] `dotnet format --verify-no-changes --severity warn` — clean.
- [ ] Windows CI to validate net48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)