### PR TITLE
Fix channel pool races: exchange-declare + GetAsync null-dequeue

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/check-coauthor.py"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/check-coauthor.py\""
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .idea/
 obj/
 bin/
+out/
 *.user
 settings.local.json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.Text.Json" Version="10.0.6" />
+    <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
+++ b/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
@@ -19,6 +19,15 @@
     <PackageReference Include="MinVer" PrivateAssets="All" />
   </ItemGroup>
 
+  <!--
+    System.Threading.Channels is in-box from net5.0 onward. For netstandard2.0 it ships
+    as a NuGet package; we currently pick it up transitively via RabbitMQ.Client but
+    declare it explicitly so we do not silently break if that dependency changes.
+  -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Channels" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests.Integration, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b81894191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066b19485ec" />
     <InternalsVisibleTo Include="$(AssemblyName).Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b81894191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066b19485ec" />

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -78,13 +78,13 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
 
         if (channel.IsOpen)
         {
-            // TryWrite returns false only when the writer has been completed (disposal
-            // raced with the return). Capacity overflow is impossible — the pool hands
-            // out at most _size channels, so the bounded channel can always accept them
-            // back. A failed write means the pool is closing; dispose the channel.
+            // TryWrite returns false when the writer has been completed (disposal raced
+            // with the return) or when the queue is full (caller returned more channels
+            // than they rented). Either way, the pool cannot take the channel; dispose
+            // it and log so accidental over-returns are visible rather than silent.
             if (!_channels.Writer.TryWrite(channel))
             {
-                return channel.DisposeAsync();
+                return DisposeSurplusChannelAsync(channel);
             }
 
             return default;
@@ -104,6 +104,19 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             await WarmUpAsync(1, _shutdownCts.Token).ConfigureAwait(false);
         });
         return default;
+    }
+
+    private static async ValueTask DisposeSurplusChannelAsync(IRabbitMQChannel channel)
+    {
+        SelfLog.WriteLine("Returned channel could not be re-pooled (pool full or closed); disposing.");
+        try
+        {
+            await channel.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            SelfLog.WriteLine("Failed to dispose surplus RabbitMQ channel: {0}", ex.Message);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -106,6 +106,10 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
         return default;
     }
 
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Surplus-channel disposal is best-effort clean-up for channels we cannot re-pool; any failure is logged to SelfLog and must not propagate into the caller's publish path (RabbitMQClient.PublishAsync's finally).")]
     private static async ValueTask DisposeSurplusChannelAsync(IRabbitMQChannel channel)
     {
         SelfLog.WriteLine("Returned channel could not be re-pooled (pool full or closed); disposing.");

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Channels;
 using RabbitMQ.Client;
 using Serilog.Debugging;
 
@@ -31,8 +31,8 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     private readonly RabbitMQClientConfiguration _config;
     private readonly IRabbitMQConnectionFactory _connectionFactory;
     private readonly int _size;
-    private readonly ConcurrentBag<IRabbitMQChannel> _available = new();
-    private readonly SemaphoreSlim _signal;
+    private readonly Channel<IRabbitMQChannel> _channels;
+    private readonly SemaphoreSlim _exchangeDeclareLock = new(1, 1);
     private readonly CancellationTokenSource _shutdownCts = new();
     private volatile bool _exchangeDeclared;
     private int _disposed;
@@ -50,7 +50,7 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
         _config = configuration;
         _connectionFactory = connectionFactory;
         _size = configuration.ChannelCount > 0 ? configuration.ChannelCount : RabbitMQClient.DEFAULT_CHANNEL_COUNT;
-        _signal = new SemaphoreSlim(0, _size);
+        _channels = Channel.CreateBounded<IRabbitMQChannel>(_size);
 
         _ = Task.Run(() => WarmUpAsync(_size, _shutdownCts.Token));
     }
@@ -58,10 +58,14 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     /// <inheritdoc />
     public async ValueTask<IRabbitMQChannel> GetAsync(CancellationToken cancellationToken = default)
     {
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
-        await _signal.WaitAsync(linked.Token).ConfigureAwait(false);
-        _available.TryTake(out var channel);
-        return channel!;
+        try
+        {
+            return await _channels.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (ChannelClosedException)
+        {
+            throw new InvalidOperationException("Channel pool has been disposed.");
+        }
     }
 
     /// <inheritdoc />
@@ -74,8 +78,15 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
 
         if (channel.IsOpen)
         {
-            _available.Add(channel);
-            _signal.Release();
+            // TryWrite returns false only when the writer has been completed (disposal
+            // raced with the return). Capacity overflow is impossible — the pool hands
+            // out at most _size channels, so the bounded channel can always accept them
+            // back. A failed write means the pool is closing; dispose the channel.
+            if (!_channels.Writer.TryWrite(channel))
+            {
+                return channel.DisposeAsync();
+            }
+
             return default;
         }
 
@@ -104,8 +115,9 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
         }
 
         _shutdownCts.Cancel();
+        _channels.Writer.TryComplete();
 
-        while (_available.TryTake(out var channel))
+        while (_channels.Reader.TryRead(out var channel))
         {
             try
             {
@@ -117,45 +129,60 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             }
         }
 
-        _signal.Dispose();
+        _exchangeDeclareLock.Dispose();
         _shutdownCts.Dispose();
+    }
+
+    private async Task WarmUpAsync(int count, CancellationToken cancellationToken)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            if (!await WarmUpSingleAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return;
+            }
+        }
     }
 
     [SuppressMessage(
         "Design",
         "CA1031:Do not catch general exception types",
         Justification = "Warm-up retries on any transient broker error so the pool can recover from network or broker hiccups without taking the sink down.")]
-    private async Task WarmUpAsync(int count, CancellationToken cancellationToken)
+    private async Task<bool> WarmUpSingleAsync(CancellationToken cancellationToken)
     {
-        for (int i = 0; i < count; i++)
+        while (!cancellationToken.IsCancellationRequested)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            try
             {
+                var channel = await CreateChannelAsync(cancellationToken).ConfigureAwait(false);
+                if (!_channels.Writer.TryWrite(channel))
+                {
+                    // Pool closed while we were creating the channel; dispose the orphan.
+                    await channel.DisposeAsync().ConfigureAwait(false);
+                    return false;
+                }
+
+                return true;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
+            catch (Exception ex)
+            {
+                SelfLog.WriteLine("Failed to warm up RabbitMQ channel: {0}", ex);
                 try
                 {
-                    var channel = await CreateChannelAsync(cancellationToken).ConfigureAwait(false);
-                    _available.Add(channel);
-                    _signal.Release();
-                    break;
+                    await Task.Delay(WarmUpRetryDelay, cancellationToken).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException)
                 {
-                    return;
-                }
-                catch (Exception ex)
-                {
-                    SelfLog.WriteLine("Failed to warm up RabbitMQ channel: {0}", ex);
-                    try
-                    {
-                        await Task.Delay(WarmUpRetryDelay, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        return;
-                    }
+                    return false;
                 }
             }
         }
+
+        return false;
     }
 
     private async Task<IRabbitMQChannel> CreateChannelAsync(CancellationToken cancellationToken)
@@ -163,14 +190,27 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
         var connection = await _connectionFactory.GetConnectionAsync().ConfigureAwait(false);
         var channel = await connection.CreateChannelAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        if (!_exchangeDeclared && _config.AutoCreateExchange)
+        if (_config.AutoCreateExchange && !_exchangeDeclared)
         {
-            await channel.ExchangeDeclareAsync(
-                _config.Exchange,
-                _config.ExchangeType,
-                _config.DeliveryMode == RabbitMQDeliveryMode.Durable,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-            _exchangeDeclared = true;
+            await _exchangeDeclareLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // Double-check under the lock: another warm-up may have declared the
+                // exchange while we were waiting for the semaphore.
+                if (!_exchangeDeclared)
+                {
+                    await channel.ExchangeDeclareAsync(
+                        _config.Exchange,
+                        _config.ExchangeType,
+                        _config.DeliveryMode == RabbitMQDeliveryMode.Durable,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                    _exchangeDeclared = true;
+                }
+            }
+            finally
+            {
+                _exchangeDeclareLock.Release();
+            }
         }
 
         return new RabbitMQChannel(channel);

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -163,7 +163,11 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
         Justification = "Warm-up retries on any transient broker error so the pool can recover from network or broker hiccups without taking the sink down.")]
     private async Task<bool> WarmUpSingleAsync(CancellationToken cancellationToken)
     {
-        while (!cancellationToken.IsCancellationRequested)
+        // while (true): all exits happen through return paths inside the body (success,
+        // orphan, or cancellation from one of the awaited operations). Looping with an
+        // explicit cancellation-check as the condition added an unreachable-in-practice
+        // branch that skewed coverage for no added safety.
+        while (true)
         {
             try
             {
@@ -194,8 +198,6 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                 }
             }
         }
-
-        return false;
     }
 
     private async Task<IRabbitMQChannel> CreateChannelAsync(CancellationToken cancellationToken)

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -441,16 +441,42 @@ public class RabbitMQChannelPoolTests
         var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
 
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        await WaitForAsync(() => connection.ReceivedCalls()
-            .Any(c => c.GetMethodInfo().Name == nameof(IConnection.CreateChannelAsync)));
 
-        // Queue is full (capacity 1, warmed with 1 channel). Returning another open
-        // channel cannot be re-pooled — TryWrite fails and we take the dispose path.
+        // Drain+return the warmed channel to guarantee the pool is at capacity before
+        // we test the surplus path. Just waiting on ReceivedCalls races with the write.
+        var warmed = await pool.GetAsync();
+        await pool.ReturnAsync(warmed);
+
         var surplusChannel = Substitute.For<IRabbitMQChannel>();
         surplusChannel.IsOpen.Returns(true);
 
         await pool.ReturnAsync(surplusChannel);
 
+        await surplusChannel.Received(1).DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ReturnAsync_WhenSurplusChannelDisposeThrows_SwallowsException()
+    {
+        // Covers the catch arm inside DisposeSurplusChannelAsync. A surplus channel
+        // whose DisposeAsync throws must not propagate the exception to the caller
+        // (RabbitMQClient.PublishAsync's finally); the error is best-effort logged
+        // to SelfLog.
+        var connection = BuildConnectionWithChannelFactory(CreateOpenChannel);
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        var warmed = await pool.GetAsync();
+        await pool.ReturnAsync(warmed);
+
+        var surplusChannel = Substitute.For<IRabbitMQChannel>();
+        surplusChannel.IsOpen.Returns(true);
+        surplusChannel.When(c => c.DisposeAsync())
+            .Do(_ => throw new InvalidOperationException("surplus-dispose-fail"));
+
+        await Should.NotThrowAsync(async () => await pool.ReturnAsync(surplusChannel));
         await surplusChannel.Received(1).DisposeAsync();
     }
 

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -321,6 +321,96 @@ public class RabbitMQChannelPoolTests
     }
 
     [Fact]
+    public async Task Warmup_DeclaresExchangeOnce_UnderConcurrentWarmup()
+    {
+        // Deterministic reproducer for the exchange-declare race on _exchangeDeclared.
+        // The first channel's ExchangeDeclareAsync blocks on a gate; while blocked, a
+        // parallel Task.Run(WarmUpAsync(1)) is spawned via ReturnAsync(brokenChannel).
+        // On master both warmups see _exchangeDeclared == false and each declare the
+        // exchange — declareCalls == 2, test fails. After the fix, the second path
+        // serialises on the guard and sees the flag set, so declareCalls == 1.
+        // TaskCompletionSource non-generic is .NET 5+; use bool variant for net48.
+        var gate = new TaskCompletionSource<bool>();
+        var createdChannels = new List<IChannel>();
+
+        var connection = BuildConnectionWithChannelFactory(() =>
+        {
+            var channel = CreateOpenChannel();
+            channel.ExchangeDeclareAsync(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<IDictionary<string, object?>?>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(gate.Task);
+
+            lock (createdChannels)
+            {
+                createdChannels.Add(channel);
+            }
+
+            return channel;
+        });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            Exchange = "x",
+            ExchangeType = "topic",
+            AutoCreateExchange = true,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        // Wait until the first channel has entered ExchangeDeclareAsync (now blocked on the gate).
+        await WaitForAsync(() =>
+        {
+            lock (createdChannels)
+            {
+                return createdChannels.Any(c => c.ReceivedCalls()
+                    .Any(call => call.GetMethodInfo().Name == nameof(IChannel.ExchangeDeclareAsync)));
+            }
+        });
+
+        // Spawn a parallel warmup. ReturnAsync of a broken channel triggers
+        // Task.Run(WarmUpAsync(1)); while the initial warmup is blocked inside
+        // ExchangeDeclareAsync, _exchangeDeclared is still false, so the buggy
+        // code enters the declare branch a second time.
+        var brokenChannel = Substitute.For<IRabbitMQChannel>();
+        brokenChannel.IsOpen.Returns(false);
+        await pool.ReturnAsync(brokenChannel);
+
+        // Wait until the second channel has been created so we know the parallel
+        // WarmUpAsync has reached CreateChannelAsync's declare check.
+        await WaitForAsync(() =>
+        {
+            lock (createdChannels)
+            {
+                return createdChannels.Count >= 2;
+            }
+        });
+
+        // Give the second warmup time to enter the declare branch if the race fires.
+        await Task.Delay(150);
+
+        gate.SetResult(true);
+
+        IChannel[] snapshot;
+        lock (createdChannels)
+        {
+            snapshot = createdChannels.ToArray();
+        }
+
+        var declareCalls = snapshot.Sum(c => c.ReceivedCalls()
+            .Count(call => call.GetMethodInfo().Name == nameof(IChannel.ExchangeDeclareAsync)));
+
+        declareCalls.ShouldBe(1);
+    }
+
+    [Fact]
     public async Task Constructor_DefaultsToSixtyFourChannels_WhenChannelCountIsZero()
     {
         // Arrange

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -411,6 +411,91 @@ public class RabbitMQChannelPoolTests
     }
 
     [Fact]
+    public async Task GetAsync_AfterDispose_ThrowsInvalidOperationException()
+    {
+        // Covers the new ChannelClosedException-to-InvalidOperationException mapping
+        // in GetAsync, which replaces the old OperationCanceledException signalling
+        // for pool disposal.
+        var connection = BuildConnectionWithChannelFactory(CreateOpenChannel);
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
+
+        var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+        await WaitForAsync(() => connection.ReceivedCalls()
+            .Any(c => c.GetMethodInfo().Name == nameof(IConnection.CreateChannelAsync)));
+
+        await pool.DisposeAsync();
+
+        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+    }
+
+    [Fact]
+    public async Task ReturnAsync_WhenPoolIsFull_DisposesSurplusChannel()
+    {
+        // Covers the new surplus-channel branch in ReturnAsync: Writer.TryWrite returns
+        // false when the bounded Channel<T> is at capacity and no GetAsync has drained
+        // it. The channel should be disposed via DisposeSurplusChannelAsync rather than
+        // leaking.
+        var connection = BuildConnectionWithChannelFactory(CreateOpenChannel);
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+        await WaitForAsync(() => connection.ReceivedCalls()
+            .Any(c => c.GetMethodInfo().Name == nameof(IConnection.CreateChannelAsync)));
+
+        // Queue is full (capacity 1, warmed with 1 channel). Returning another open
+        // channel cannot be re-pooled — TryWrite fails and we take the dispose path.
+        var surplusChannel = Substitute.For<IRabbitMQChannel>();
+        surplusChannel.IsOpen.Returns(true);
+
+        await pool.ReturnAsync(surplusChannel);
+
+        await surplusChannel.Received(1).DisposeAsync();
+    }
+
+    [Fact]
+    public async Task WarmUp_DisposesOrphanChannel_WhenPoolClosesBeforeTryWrite()
+    {
+        // Covers the orphan-dispose branch in WarmUpSingleAsync: CreateChannelAsync
+        // completes AFTER the pool has been disposed, so Writer.TryWrite returns false
+        // and the newly-created channel must be disposed rather than leaked.
+        var gate = new TaskCompletionSource<bool>();
+        var channelCreationEntered = new TaskCompletionSource<bool>();
+        var disposedChannels = new List<IChannel>();
+
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                channelCreationEntered.TrySetResult(true);
+                await gate.Task;
+                var ch = CreateOpenChannel();
+                ch.When(c => c.Dispose()).Do(_ => disposedChannels.Add(ch));
+                return ch;
+            });
+
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
+
+        var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        // Wait until WarmUp has entered CreateChannelAsync (now blocked on the gate).
+        await channelCreationEntered.Task;
+
+        // Dispose the pool while the channel is still being "created". This calls
+        // Writer.TryComplete(), so the eventual TryWrite in WarmUpSingleAsync fails.
+        await pool.DisposeAsync();
+
+        // Release the gate: CreateChannelAsync now returns, WarmUpSingleAsync attempts
+        // TryWrite, fails, and should dispose the orphan channel.
+        gate.SetResult(true);
+
+        await WaitForAsync(() => disposedChannels.Count >= 1);
+        disposedChannels.Count.ShouldBe(1);
+    }
+
+    [Fact]
     public async Task Constructor_DefaultsToSixtyFourChannels_WhenChannelCountIsZero()
     {
         // Arrange

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -393,8 +393,12 @@ public class RabbitMQChannelPoolTests
             }
         });
 
-        // Give the second warmup time to enter the declare branch if the race fires.
-        await Task.Delay(150);
+        // Give the second warmup time to pass CreateChannelAsync and enter the declare
+        // check. On master (buggy code) it must reach ExchangeDeclareAsync before we
+        // release the gate, otherwise the flag will already be set by the first warmup
+        // and the race will not fire (false green). 500 ms is generous for slow CI
+        // workers; this happens on every run so the cost is bounded.
+        await Task.Delay(500);
 
         gate.SetResult(true);
 


### PR DESCRIPTION
Fixes #277.

## Summary

Two latent concurrency bugs in `RabbitMQChannelPool`.

### 1. Exchange-declare race

Concurrent warm-up tasks could all observe `_exchangeDeclared == false` before any of them flipped it, then each call `ExchangeDeclareAsync` redundantly. Fix: guard the declare with a `SemaphoreSlim(1, 1)` + double-check so the exchange is declared exactly once.

### 2. `GetAsync` null-dequeue race

`_signal.WaitAsync` + `_available.TryTake` were not atomic — a concurrent `DisposeAsync` could drain the bag between the two, and the `return channel!` handed the caller a null reference. Fix: replace `ConcurrentBag<T>` + `SemaphoreSlim` with a bounded `System.Threading.Channels.Channel<T>`. `Reader.ReadAsync` couples dequeue and signalling atomically, and `Writer.TryComplete` on dispose surfaces via `ChannelClosedException` → `InvalidOperationException`, never null. Eliminates the bug class by construction.

## ⚠️ Behavior change (potentially breaking for downstream consumers)

`GetAsync` invoked on a disposed pool now throws **`InvalidOperationException`** instead of **`OperationCanceledException`**. The old behaviour relied on linking `_shutdownCts.Token` into the semaphore wait; the new `Channel<T>`-based implementation signals closure via `ChannelClosedException`, which this PR maps to `InvalidOperationException("Channel pool has been disposed.")`.

Any downstream code that catches `OperationCanceledException` specifically to distinguish "pool shut down" from "user cancellation" will need to catch `InvalidOperationException` instead. User-supplied cancellation tokens still produce `OperationCanceledException` as before.

## Red-first verification

Added `Warmup_DeclaresExchangeOnce_UnderConcurrentWarmup` — gates the mocked `ExchangeDeclareAsync` with a `TaskCompletionSource<bool>`, spawns a parallel warm-up via `ReturnAsync(broken)`, and asserts `declareCalls == 1`.

- On master: `declareCalls == 2` → test fails.
- After fix: `declareCalls == 1` → test passes.

## Notes

- `WarmUpSingleAsync` extracted from `WarmUpAsync` to keep cognitive complexity in check after the orphan-dispose branch was added.
- `RabbitMQChannelPool` is `internal`; no public API change. Public API approval snapshot unchanged.
- Explicit `PackageReference` added for `System.Threading.Channels` on `netstandard2.0` so we no longer depend on it being transitively pulled in via RabbitMQ.Client.
- Pre-existing `IChannel` leak if `ExchangeDeclareAsync` throws inside `CreateChannelAsync` — tracked separately as #280.
- Out of scope (tracked separately): unbounded warm-up retries, shutdown-vs-timeout messaging polish, `IRabbitMQConnectionFactory.CloseAsync` pre-existing semaphore oddity.

## Test plan

- [x] `dotnet build -c Release` — all TFMs (`netstandard2.0`, `net8.0`, `net10.0`, `net48` for tests).
- [x] Unit tests — 48/48 on net10.0, 47/47 on net8.0 (both now include the new reproducer and three coverage tests).
- [x] Integration tests — 26/26 on net10.0 against docker-compose brokers.
- [x] `dotnet format --verify-no-changes --severity warn` — clean.
- [x] Reproducer demonstrates red-before-fix / green-after-fix.
- [x] Codecov patch and project gates both green.
- [x] Windows CI validates net48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)