### PR TITLE
Fix SSL ServerName leaking across hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,17 @@ are on an internal interface; no public API change.
 the broker on each retry; repeated failures could accumulate up to the connection's
 `channel_max` limit and then stop opening new channels entirely.
 
+### Fixed SSL `ServerName` leaking across hostnames
+
+When `Hostnames` contained more than one entry and `SslOption` was enabled, every
+`AmqpTcpEndpoint` was pointed at the **same** `SslOption` instance and the SNI
+`ServerName` was mutated in place. The first hostname's value was baked in and reused
+for every subsequent connection, causing SNI mismatches against brokers with
+host-specific certificates. The connection factory now shallow-clones the
+`SslOption` per endpoint and derives `ServerName` from the caller-provided value or
+the endpoint's own hostname — never from a previously-mutated shared object. The
+caller's `SslOption` is no longer mutated.
+
 ### Public `Validate()` on configuration classes
 
 `RabbitMQClientConfiguration` and `RabbitMQSinkConfiguration` now expose a public

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConnectionFactory.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConnectionFactory.cs
@@ -66,7 +66,13 @@ internal sealed class RabbitMQConnectionFactory : IRabbitMQConnectionFactory
         return _connection;
     }
 
-    private IEnumerable<AmqpTcpEndpoint> GetAmqpTcpEndpoints() =>
+    /// <summary>
+    /// Builds the <see cref="AmqpTcpEndpoint"/> list used by the underlying
+    /// RabbitMQ client. Exposed internally so tests can exercise per-endpoint
+    /// SSL configuration without a running broker.
+    /// </summary>
+    /// <returns>One endpoint per configured hostname.</returns>
+    internal IEnumerable<AmqpTcpEndpoint> GetAmqpTcpEndpoints() =>
         _config.Hostnames.Select(hostname =>
         {
             var amqpTcpEndpoint = AmqpTcpEndpoint.Parse(hostname);
@@ -77,14 +83,44 @@ internal sealed class RabbitMQConnectionFactory : IRabbitMQConnectionFactory
 
             if (_connectionFactory.Ssl.Enabled)
             {
-                amqpTcpEndpoint.Ssl = _connectionFactory.Ssl;
-                amqpTcpEndpoint.Ssl.ServerName = !string.IsNullOrEmpty(_connectionFactory.Ssl.ServerName)
-                    ? _connectionFactory.Ssl.ServerName
-                    : amqpTcpEndpoint.HostName;
+                // Shallow-clone the SslOption per endpoint so:
+                //   1. Every endpoint carries its own SNI ServerName matching its own
+                //      hostname (prior code mutated a single shared SslOption, leaking
+                //      the first hostname into every subsequent endpoint — issue #289).
+                //   2. The caller-supplied SslOption is never mutated; downstream state
+                //      the RabbitMQ client may attach to the option is per-connection.
+                amqpTcpEndpoint.Ssl = CloneForEndpoint(_connectionFactory.Ssl);
+                if (string.IsNullOrEmpty(amqpTcpEndpoint.Ssl.ServerName))
+                {
+                    amqpTcpEndpoint.Ssl.ServerName = amqpTcpEndpoint.HostName;
+                }
             }
 
             return amqpTcpEndpoint;
         }).ToList();
+
+    /// <summary>
+    /// Shallow-clone of <see cref="SslOption"/> so each endpoint gets an independent
+    /// instance that can safely carry its own SNI <see cref="SslOption.ServerName"/>.
+    /// Delegates and certificate collections stay by reference — they are treated as
+    /// immutable configuration inputs by callers and by <c>RabbitMQ.Client</c>.
+    /// </summary>
+    /// <param name="source">The caller-provided option; never mutated.</param>
+    /// <returns>A new <see cref="SslOption"/> with the same values.</returns>
+    private static SslOption CloneForEndpoint(SslOption source) =>
+        new()
+        {
+            AcceptablePolicyErrors = source.AcceptablePolicyErrors,
+            CertPassphrase = source.CertPassphrase,
+            CertPath = source.CertPath,
+            Certs = source.Certs,
+            CertificateSelectionCallback = source.CertificateSelectionCallback,
+            CertificateValidationCallback = source.CertificateValidationCallback,
+            CheckCertificateRevocation = source.CheckCertificateRevocation,
+            Enabled = source.Enabled,
+            ServerName = source.ServerName,
+            Version = source.Version,
+        };
 
     private ConnectionFactory GetConnectionFactory()
     {

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQConnectionFactoryTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQConnectionFactoryTests.cs
@@ -1,0 +1,92 @@
+namespace Serilog.Sinks.RabbitMQ.Tests;
+
+public class RabbitMQConnectionFactoryTests
+{
+    private static RabbitMQClientConfiguration SslSample(params string[] hostnames) => new()
+    {
+        Hostnames = hostnames.ToList(),
+        Username = "guest",
+        Password = "guest",
+        SslOption = new SslOption { Enabled = true },
+    };
+
+    [Fact]
+    public void GetAmqpTcpEndpoints_EachEndpointHasServerNameMatchingItsOwnHostname_WhenNotExplicitlySet()
+    {
+        // Bug reproducer for issue #289. Prior behaviour: the SslOption was shared by
+        // reference across every endpoint, and the first iteration's ServerName
+        // assignment leaked into later iterations. Second endpoint's Ssl.ServerName
+        // ended up equal to the FIRST hostname.
+        var configuration = SslSample("rabbit-a.example.com", "rabbit-b.example.com");
+        using var cts = new CancellationTokenSource();
+        var sut = new RabbitMQConnectionFactory(configuration, cts);
+
+        var endpoints = sut.GetAmqpTcpEndpoints().ToArray();
+
+        endpoints.Length.ShouldBe(2);
+        endpoints[0].Ssl.ServerName.ShouldBe("rabbit-a.example.com");
+        endpoints[1].Ssl.ServerName.ShouldBe("rabbit-b.example.com");
+    }
+
+    [Fact]
+    public void GetAmqpTcpEndpoints_EachEndpointHasIndependentSslOption()
+    {
+        // The returned endpoints must not share a single SslOption reference; otherwise
+        // any downstream mutation bleeds across connections.
+        var configuration = SslSample("rabbit-a.example.com", "rabbit-b.example.com");
+        using var cts = new CancellationTokenSource();
+        var sut = new RabbitMQConnectionFactory(configuration, cts);
+
+        var endpoints = sut.GetAmqpTcpEndpoints().ToArray();
+
+        ReferenceEquals(endpoints[0].Ssl, endpoints[1].Ssl).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetAmqpTcpEndpoints_DoesNotMutateCallerProvidedSslOption()
+    {
+        // The caller's SslOption.ServerName must stay as they left it. Currently the
+        // old code writes through the shared reference and silently updates this to
+        // the first hostname.
+        var configuration = SslSample("rabbit-a.example.com", "rabbit-b.example.com");
+        using var cts = new CancellationTokenSource();
+        var sut = new RabbitMQConnectionFactory(configuration, cts);
+
+        _ = sut.GetAmqpTcpEndpoints().ToArray();
+
+        configuration.SslOption!.ServerName.ShouldBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void GetAmqpTcpEndpoints_AppliesConfiguredPortToEveryEndpoint()
+    {
+        // Covers the Port override branch in GetAmqpTcpEndpoints so the coverage
+        // gate for a method we modified stays green.
+        var configuration = SslSample("rabbit-a.example.com", "rabbit-b.example.com");
+        configuration.Port = 5673;
+        using var cts = new CancellationTokenSource();
+        var sut = new RabbitMQConnectionFactory(configuration, cts);
+
+        var endpoints = sut.GetAmqpTcpEndpoints().ToArray();
+
+        endpoints[0].Port.ShouldBe(5673);
+        endpoints[1].Port.ShouldBe(5673);
+    }
+
+    [Fact]
+    public void GetAmqpTcpEndpoints_RespectsExplicitServerName_ForAllEndpoints()
+    {
+        // When the user explicitly sets ServerName (e.g. shared wildcard cert CN),
+        // every endpoint should still use that value. This matches the prior behaviour
+        // for that specific case; the fix must not regress it.
+        var configuration = SslSample("rabbit-a.example.com", "rabbit-b.example.com");
+        configuration.SslOption!.ServerName = "cluster.example.com";
+        using var cts = new CancellationTokenSource();
+        var sut = new RabbitMQConnectionFactory(configuration, cts);
+
+        var endpoints = sut.GetAmqpTcpEndpoints().ToArray();
+
+        endpoints[0].Ssl.ServerName.ShouldBe("cluster.example.com");
+        endpoints[1].Ssl.ServerName.ShouldBe("cluster.example.com");
+    }
+}


### PR DESCRIPTION
Fixes #289.

## Summary

`RabbitMQConnectionFactory.GetAmqpTcpEndpoints` pointed every `AmqpTcpEndpoint` at the **same** `SslOption` reference and mutated `ServerName` in place. The first hostname's value was baked in and leaked into every subsequent endpoint, so any broker beyond the first in `Hostnames` saw an SNI mismatch against a host-specific certificate.

## Fix

Shallow-clone the `SslOption` per endpoint via a new `CloneForEndpoint` helper. Derive `ServerName` from the caller-provided value (when set) or the endpoint's own hostname — never from a previously-mutated shared object. The caller's `SslOption` is no longer mutated.

Delegates (`CertificateSelectionCallback`, `CertificateValidationCallback`) and `X509CertificateCollection` stay by reference: they are treated as immutable configuration inputs by `RabbitMQ.Client` and deep-cloning certs introduces resource-ownership ambiguity without any real safety benefit. Per-hostname `SslOption` (distinct certs per broker) is out of scope — already achievable by constructing multiple `RabbitMQClient` instances.

## Red-first verification

Promoted `GetAmqpTcpEndpoints` from `private` to `internal` (class itself is already `internal`; no public API change) so tests can exercise endpoint construction without a running broker. Added four unit tests in the unit-test project:

| Test | On master | After fix |
|---|---|---|
| `EachEndpointHasServerNameMatchingItsOwnHostname_WhenNotExplicitlySet` | red — second endpoint gets first hostname | green |
| `EachEndpointHasIndependentSslOption` | red — shared reference | green |
| `DoesNotMutateCallerProvidedSslOption` | red — ServerName written back to caller's option | green |
| `RespectsExplicitServerName_ForAllEndpoints` | green (unaffected behaviour; guards against regression) | green |
| `AppliesConfiguredPortToEveryEndpoint` | green | green (covers the Port branch that a modified method should keep covered) |

## Test plan

- [x] `dotnet build -c Release --no-restore` — all TFMs (`netstandard2.0`, `net8.0`, `net10.0`, `net48` for tests).
- [x] Unit tests — 78/78 on net10.0, 77/77 on net8.0 (3× repeat runs on net10.0, all stable).
- [x] Integration tests — 26/26 on net10.0 against the docker-compose brokers.
- [x] `dotnet format --verify-no-changes --severity warn` — clean.
- [x] Coverage — `GetAmqpTcpEndpoints` 25/25 lines, `CloneForEndpoint` 13/13 lines, 100% on both.
- [ ] Windows CI validates net48.

## Notes

- `RabbitMQConnectionFactory` is `internal`; no public API change. Public API approval snapshot unchanged.
- The `GetConnectionFactory` / `CloseAsync` / `DisposeAsync` / `GetConnectionAsync` methods in this file have pre-existing partial coverage because they hit the real RabbitMQ client and are only exercised by integration tests. None of them are part of this PR's diff.
- CHANGELOG entry added under `9.0.0 [not published]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)