### PR TITLE
Implement ISetLoggingFailureListener for Serilog 4.1+ WriteTo.Fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,23 @@ are on an internal interface; no public API change.
 the broker on each retry; repeated failures could accumulate up to the connection's
 `channel_max` limit and then stop opening new channels entirely.
 
+### `ISetLoggingFailureListener` for Serilog 4.1+ FallbackChain
+
+`RabbitMQSink` now implements `ISetLoggingFailureListener` so failures can be routed
+through Serilog's `WriteTo.Fallback(...)` pipeline. When a publish fails and a
+listener has been registered, `OnLoggingFailed` is invoked with
+`LoggingFailureKind.Permanent` and the batch. If the legacy
+`EmitEventFailureHandling.WriteToFailureSink` path is also wired and that sink
+itself fails, the listener is escalated to `LoggingFailureKind.Final` with an
+`AggregateException` wrapping both causes.
+
+The existing `failureSinkConfiguration` mechanism is **not** deprecated in this
+release — `Serilog.Settings.Configuration` does not yet support declarative
+`Fallback` configuration, so appsettings.json users have no migration path.
+Both mechanisms coexist; users can opt into the new listener-based routing today
+if they configure sinks in code, and the legacy parameter will be marked obsolete
+once upstream declarative support lands.
+
 ### Fixed SSL `ServerName` leaking across hostnames
 
 When `Hostnames` contained more than one entry and `SslOption` was enabled, every

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -25,7 +25,7 @@ namespace Serilog.Sinks.RabbitMQ;
 /// <summary>
 /// Serilog RabbitMQ Sink - lets you log to RabbitMQ using Serilog.
 /// </summary>
-public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposable
+public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, ISetLoggingFailureListener, IDisposable
 {
     private static readonly RecyclableMemoryStreamManager _manager = new();
     private static readonly Encoding _utf8NoBOM = new UTF8Encoding(false);
@@ -37,6 +37,7 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
     private readonly ISendMessageEvents _sendMessageEvents;
     private readonly bool _persistent;
     private readonly string _routingKey;
+    private ILoggingFailureListener? _failureListener;
     private bool _disposedValue;
 
     /// <summary>
@@ -90,7 +91,30 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
     }
 
     /// <inheritdoc cref="ILogEventSink.Emit" />
-    public void Emit(LogEvent logEvent) => AsyncHelpers.RunSync(() => EmitAsync(logEvent));
+    public void Emit(LogEvent logEvent)
+    {
+        try
+        {
+            AsyncHelpers.RunSync(() => EmitAsync(logEvent));
+        }
+        catch (Exception ex)
+        {
+            // Audit path: notify the listener before propagating so downstream observers
+            // (e.g. WriteTo.Fallback) see the failed event even though we keep audit
+            // semantics by rethrowing.
+            NotifyListener(sinkFailure: null, events: new[] { logEvent }, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetFailureListener(ILoggingFailureListener failureListener)
+    {
+        // Per ISetLoggingFailureListener contract this is called once during
+        // initialization on the init thread, before logging starts. Plain field
+        // assignment is sufficient; no synchronisation required.
+        _failureListener = failureListener;
+    }
 
     /// <inheritdoc cref="IBatchedLogEventSink.EmitBatchAsync" />
     public async Task EmitBatchAsync(IReadOnlyCollection<LogEvent> batch)
@@ -174,6 +198,7 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
             SelfLog.WriteLine("Caught exception while performing bulk operation to RabbitMQ: {0}", ex);
         }
 
+        Exception? sinkFailure = null;
         if (_emitEventFailureHandling.HasFlag(EmitEventFailureHandling.WriteToFailureSink) && _failureSink != null)
         {
             // Send to a failure sink
@@ -187,13 +212,61 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
             catch (Exception exSink)
             {
                 // No exception is thrown to the caller
+                sinkFailure = exSink;
                 SelfLog.WriteLine("Caught exception while emitting to failure sink {0}: {1}", _failureSink, exSink.Message);
                 SelfLog.WriteLine("Failure sink exception: {0}", exSink);
                 SelfLog.WriteLine("Original exception: {0}", ex);
             }
         }
 
+        NotifyListener(sinkFailure, events, ex);
+
         // Return true if the exception has been handled. e.g. when the exception doesn't need to be rethrown.
         return !_emitEventFailureHandling.HasFlag(EmitEventFailureHandling.ThrowException);
+    }
+
+    /// <summary>
+    /// Notifies the Serilog 4.1+ <see cref="ILoggingFailureListener"/> (when one has been
+    /// registered via <see cref="ISetLoggingFailureListener"/>) that a publish has failed.
+    /// When the legacy <see cref="EmitEventFailureHandling.WriteToFailureSink"/> path also
+    /// failed, escalates to <see cref="LoggingFailureKind.Final"/> with an
+    /// <see cref="AggregateException"/> wrapping both causes.
+    /// </summary>
+    /// <param name="sinkFailure">Non-null when the legacy failure sink itself threw.</param>
+    /// <param name="events">Log events associated with the failure.</param>
+    /// <param name="ex">Original RabbitMQ publish exception.</param>
+    private void NotifyListener(Exception? sinkFailure, IReadOnlyCollection<LogEvent> events, Exception ex)
+    {
+        if (_failureListener is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (sinkFailure is null)
+            {
+                _failureListener.OnLoggingFailed(
+                    this,
+                    LoggingFailureKind.Permanent,
+                    "RabbitMQ publish failed.",
+                    events,
+                    ex);
+            }
+            else
+            {
+                _failureListener.OnLoggingFailed(
+                    this,
+                    LoggingFailureKind.Final,
+                    "RabbitMQ publish failed, and the configured failure sink also failed.",
+                    events,
+                    new AggregateException(ex, sinkFailure));
+            }
+        }
+        catch (Exception exListener)
+        {
+            // A throwing listener must not recurse; drop to SelfLog and continue.
+            SelfLog.WriteLine("Failure listener threw: {0}", exListener);
+        }
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
@@ -102,12 +102,13 @@ namespace Serilog.Sinks.RabbitMQ
         NonDurable = 1,
         Durable = 2,
     }
-    public sealed class RabbitMQSink : Serilog.Core.IBatchedLogEventSink, Serilog.Core.ILogEventSink, System.IDisposable
+    public sealed class RabbitMQSink : Serilog.Core.IBatchedLogEventSink, Serilog.Core.ILogEventSink, Serilog.Core.ISetLoggingFailureListener, System.IDisposable
     {
         public void Dispose() { }
         public void Emit(Serilog.Events.LogEvent logEvent) { }
         public System.Threading.Tasks.Task EmitBatchAsync(System.Collections.Generic.IReadOnlyCollection<Serilog.Events.LogEvent> batch) { }
         public System.Threading.Tasks.Task OnEmptyBatchAsync() { }
+        public void SetFailureListener(Serilog.Core.ILoggingFailureListener failureListener) { }
     }
     public class RabbitMQSinkConfiguration
     {

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -401,4 +401,178 @@ public class RabbitMQSinkTests
         LoggerAuditSinkConfiguration config = null!;
         Should.Throw<ArgumentNullException>(() => config.RabbitMQ((_, _) => { })).ParamName.ShouldBe("loggerAuditSinkConfiguration");
     }
+
+    private static RabbitMQSink CreateSut(
+        IRabbitMQClient rabbitMQClient,
+        EmitEventFailureHandling emitEventFailureHandling = EmitEventFailureHandling.Ignore,
+        ILogEventSink? failureSink = null)
+    {
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+        return new RabbitMQSink(rabbitMQClient, textFormatter, messageEvents, emitEventFailureHandling, failureSink);
+    }
+
+    private static IRabbitMQClient ClientThatFailsPublish(string message = "publish-fail")
+    {
+        var client = Substitute.For<IRabbitMQClient>();
+        client.When(x => x.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>()))
+            .Do(_ => throw new InvalidOperationException(message));
+        return client;
+    }
+
+    [Fact]
+    public async Task EmitBatchAsync_NotifiesListener_WithPermanent_WhenPublishFailsAndNoFailureSink()
+    {
+        // Matrix row: only listener configured, publish fails → Permanent + original exception.
+        var listener = Substitute.For<ILoggingFailureListener>();
+        var sut = CreateSut(ClientThatFailsPublish());
+        sut.SetFailureListener(listener);
+
+        await sut.EmitBatchAsync([LogEventBuilder.Create().Build()]);
+
+        listener.Received(1).OnLoggingFailed(
+            sut,
+            LoggingFailureKind.Permanent,
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyCollection<LogEvent>>(),
+            Arg.Is<Exception>(e => e is InvalidOperationException && e.Message == "publish-fail"));
+    }
+
+    [Fact]
+    public async Task EmitBatchAsync_NotifiesListenerAndLegacySink_WhenBothConfiguredAndLegacySucceeds()
+    {
+        // Matrix row: both wired, legacy succeeds, listener still fires with Permanent +
+        // the ORIGINAL publish exception (not an AggregateException).
+        var listener = Substitute.For<ILoggingFailureListener>();
+        var failureSink = Substitute.For<ILogEventSink>();
+        var sut = CreateSut(
+            ClientThatFailsPublish(),
+            EmitEventFailureHandling.WriteToFailureSink,
+            failureSink);
+        sut.SetFailureListener(listener);
+
+        var logEvent = LogEventBuilder.Create().Build();
+        await sut.EmitBatchAsync([logEvent]);
+
+        failureSink.Received(1).Emit(logEvent);
+        listener.Received(1).OnLoggingFailed(
+            sut,
+            LoggingFailureKind.Permanent,
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyCollection<LogEvent>>(),
+            Arg.Is<Exception>(e => e is InvalidOperationException));
+    }
+
+    [Fact]
+    public async Task EmitBatchAsync_EscalatesToFinal_WhenLegacyFailureSinkAlsoThrows()
+    {
+        // Matrix row: both wired, legacy fails too → Final + AggregateException(publish, sink).
+        var listener = Substitute.For<ILoggingFailureListener>();
+        var failureSink = Substitute.For<ILogEventSink>();
+        failureSink.When(x => x.Emit(Arg.Any<LogEvent>()))
+            .Do(_ => throw new InvalidOperationException("sink-fail"));
+
+        var sut = CreateSut(
+            ClientThatFailsPublish(),
+            EmitEventFailureHandling.WriteToFailureSink,
+            failureSink);
+        sut.SetFailureListener(listener);
+
+        await sut.EmitBatchAsync([LogEventBuilder.Create().Build()]);
+
+        // Delegate predicate (not expression-tree) because Arg.Is overload selection
+        // otherwise picks the Expression<...> form which rejects declaration patterns.
+        listener.Received(1).OnLoggingFailed(
+            sut,
+            LoggingFailureKind.Final,
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyCollection<LogEvent>>(),
+            Arg.Is<Exception>(e => IsPublishAndSinkAggregate(e)));
+    }
+
+    private static bool IsPublishAndSinkAggregate(Exception e) =>
+        e is AggregateException agg
+        && agg.InnerExceptions.Count == 2
+        && agg.InnerExceptions[0].Message == "publish-fail"
+        && agg.InnerExceptions[1].Message == "sink-fail";
+
+    [Fact]
+    public async Task EmitBatchAsync_DoesNotThrow_WhenFailureListenerThrows()
+    {
+        // A throwing listener must be swallowed (SelfLog entry) without recursing.
+        var listener = Substitute.For<ILoggingFailureListener>();
+        listener.When(x => x.OnLoggingFailed(
+                Arg.Any<object>(),
+                Arg.Any<LoggingFailureKind>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyCollection<LogEvent>>(),
+                Arg.Any<Exception>()))
+            .Do(_ => throw new InvalidOperationException("listener-fail"));
+
+        var sut = CreateSut(ClientThatFailsPublish());
+        sut.SetFailureListener(listener);
+
+        var act = () => sut.EmitBatchAsync([LogEventBuilder.Create().Build()]);
+
+        await Should.NotThrowAsync(act);
+    }
+
+    [Fact]
+    public async Task EmitBatchAsync_DoesNotNotifyListener_WhenListenerIsNotSet()
+    {
+        // Baseline: no listener — legacy behaviour unchanged, no exception about null deref.
+        var sut = CreateSut(ClientThatFailsPublish());
+
+        var act = () => sut.EmitBatchAsync([LogEventBuilder.Create().Build()]);
+
+        await Should.NotThrowAsync(act);
+    }
+
+    [Fact]
+    public void Emit_Audit_NotifiesListenerAndRethrows_WhenPublishFails()
+    {
+        // Audit path: listener is notified before the exception propagates (preserving
+        // audit semantics of "throw on failure").
+        var listener = Substitute.For<ILoggingFailureListener>();
+        var sut = CreateSut(ClientThatFailsPublish());
+        sut.SetFailureListener(listener);
+
+        var logEvent = LogEventBuilder.Create().Build();
+        Should.Throw<InvalidOperationException>(() => sut.Emit(logEvent));
+
+        listener.Received(1).OnLoggingFailed(
+            sut,
+            LoggingFailureKind.Permanent,
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlyCollection<LogEvent>>(e => e.Count == 1 && e.Single() == logEvent),
+            Arg.Is<Exception>(e => e is InvalidOperationException && e.Message == "publish-fail"));
+    }
+
+    [Fact]
+    public void SetFailureListener_ReplacesPreviouslyRegisteredListener()
+    {
+        // Defensive: sinks should be okay with the pipeline calling SetFailureListener
+        // more than once during construction, even though the contract says "once".
+        var first = Substitute.For<ILoggingFailureListener>();
+        var second = Substitute.For<ILoggingFailureListener>();
+        var sut = CreateSut(ClientThatFailsPublish());
+
+        sut.SetFailureListener(first);
+        sut.SetFailureListener(second);
+
+        Should.Throw<InvalidOperationException>(() => sut.Emit(LogEventBuilder.Create().Build()));
+
+        first.DidNotReceive().OnLoggingFailed(
+            Arg.Any<object>(),
+            Arg.Any<LoggingFailureKind>(),
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyCollection<LogEvent>>(),
+            Arg.Any<Exception>());
+        second.Received(1).OnLoggingFailed(
+            Arg.Any<object>(),
+            Arg.Any<LoggingFailureKind>(),
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyCollection<LogEvent>>(),
+            Arg.Any<Exception>());
+    }
 }


### PR DESCRIPTION
Fixes #291.

## Summary

`RabbitMQSink` now implements `ISetLoggingFailureListener` so failures can be routed through Serilog 4.1+'s `WriteTo.Fallback(...)` pipeline. Previously, all publish exceptions were caught and handled internally via `EmitEventFailureHandling` + `failureSinkConfiguration`; the surrounding `BatchingSink` never saw them, so wrapping our sink in `WriteTo.Fallback(...)` did nothing.

## Behaviour matrix

| Scenario | Legacy `_failureSink` | `ILoggingFailureListener` |
|---|---|---|
| Only legacy configured, publish fails | Gets events | — |
| Only listener configured, publish fails | — | `OnLoggingFailed(Permanent, events, ex)` |
| Both configured, publish fails, legacy succeeds | Gets events | `OnLoggingFailed(Permanent, events, ex)` |
| Both configured, publish fails, legacy also fails | SelfLog entries | `OnLoggingFailed(Final, events, AggregateException(ex, sinkEx))` |
| Neither configured | SelfLog if flagged; rethrow if flagged | — |

**Log-to-both semantics.** `OnLoggingFailed` is observational (`void` return) — it can't signal "handled, stop." A user configuring both presumably wants defensive multi-path handling.

**Final on escalation.** When the legacy sink also fails, the listener receives `LoggingFailureKind.Final` with an `AggregateException`. Downstream observers can react differently to `Final` (e.g. flush synchronously).

**Audit path notifies before rethrowing.** The sync `Emit` path invokes the listener then propagates the original exception — preserves audit semantics while still surfacing failures to Fallback.

**Listener failures are swallowed.** A throwing listener writes to `SelfLog` once and does not recurse.

## Deprecation: intentionally NOT done here

`failureSinkConfiguration` and `EmitEventFailureHandling.WriteToFailureSink` remain undecorated. `Serilog.Settings.Configuration` does not yet support declarative `Fallback` configuration — appsettings.json users would have no migration path. Once upstream support lands (maintainer has a PR in flight), a follow-up will `[Obsolete]` the legacy parameter with a concrete appsettings.json example and plan removal for a later major.

## Test plan

- [x] `dotnet build -c Release` — all TFMs (`netstandard2.0`, `net8.0`, `net10.0`, `net48` for tests).
- [x] Unit tests — 85/85 on net10.0 (3× repeat runs stable), 84/84 on net8.0. 7 new cases covering every row of the matrix + setter-replace + no-listener baseline + audit path + throwing-listener.
- [x] Integration tests — 26/26 on net10.0 against docker-compose brokers.
- [x] `dotnet format --verify-no-changes --severity warn` — clean.
- [x] Coverage — 100% on `SetFailureListener`, `NotifyListener`, the updated `HandleException`, and the new try/catch in `Emit`.
- [x] Public API approval snapshot regenerated — exactly two new lines (interface + method).
- [ ] Windows CI validates net48.

## API surface

Additive:

```csharp
public sealed class RabbitMQSink
    : IBatchedLogEventSink,
      ILogEventSink,
      ISetLoggingFailureListener,   // new
      IDisposable
{
    public void SetFailureListener(ILoggingFailureListener failureListener) { }  // new
    // ... existing members unchanged ...
}
```

No other user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)