### PR TITLE
Align RabbitMQSink failure handling with Serilog's BatchingSink model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,38 @@ are on an internal interface; no public API change.
 the broker on each retry; repeated failures could accumulate up to the connection's
 `channel_max` limit and then stop opening new channels entirely.
 
+### Aligned failure handling with Serilog's `BatchingSink` model
+
+`RabbitMQSink.EmitBatchAsync` no longer silently swallows publish failures by default.
+Exceptions now propagate to Serilog's `BatchingSink`, whose listener plumbing
+observes the failure — this is what makes `WriteTo.Fallback(s => s.RabbitMQ(...), fallback: s => s.File(...))`
+route failed events to the fallback sink.
+
+The `EmitEventFailureHandling` flags still work and compose as follows:
+
+| Flags set                                | Behaviour                                                                 |
+|------------------------------------------|---------------------------------------------------------------------------|
+| *(default: `Ignore`)*                    | Rethrow. `BatchingSink` catches, notifies its listener.                   |
+| `WriteToSelfLog`                         | Log to `SelfLog`, then rethrow.                                           |
+| `WriteToFailureSink` *(legacy routing)*  | Emit events to the configured failure sink, **do not rethrow** (unchanged). |
+| `WriteToFailureSink | WriteToSelfLog`    | Log + emit, **do not rethrow** (unchanged).                               |
+| `ThrowException`                         | Rethrow (unchanged).                                                      |
+| `WriteToFailureSink | ThrowException`    | Emit events to the failure sink **and** rethrow (unchanged).              |
+
+**Behaviour change to flag:** users on the `Ignore` default who did not wire
+`failureSinkConfiguration` previously saw silent failures. Publish errors now
+surface via `BatchingSink`'s default listener (`SelfLog`), or via the listener set
+by a `WriteTo.Fallback(...)` wrapper. Consider this an observability upgrade —
+silent logging failures are almost always undesirable. To preserve the old
+silent behaviour you can set `emitEventFailure = WriteToFailureSink` and wire
+`failureSinkConfiguration` to a no-op sink.
+
+`RabbitMQSink` also now implements `ISetLoggingFailureListener` — this is only
+relevant for the audit path (`AuditTo.RabbitMQ(...)`) and direct-construct users.
+`BatchingSink` does not forward `SetFailureListener` to its inner sink by design,
+so the batched pipeline still routes via `BatchingSink`'s own listener as
+described above.
+
 ### Fixed SSL `ServerName` leaking across hostnames
 
 When `Hostnames` contained more than one entry and `SslOption` was enabled, every
@@ -210,3 +242,6 @@ renamed to `channelCount`. Update appsettings JSON / `App.config` keys from `max
 - `RabbitMQClientConfiguration.MaxChannels` is now `[Obsolete]`; use `ChannelCount`
 - `RabbitMQSinkConfiguration.QueueLimit` must be greater than zero when set; zero or
   negative values now throw `ArgumentOutOfRangeException` at configuration time
+- `RabbitMQSink.EmitBatchAsync` propagates publish exceptions by default instead of
+  silently swallowing them. Use `EmitEventFailureHandling.WriteToFailureSink` to keep
+  legacy catch-and-route behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,8 +172,8 @@ The `EmitEventFailureHandling` flags still work and compose as follows:
 
 | Flags set                                | Behaviour                                                                 |
 |------------------------------------------|---------------------------------------------------------------------------|
-| *(default: `Ignore`)*                    | Rethrow. `BatchingSink` catches, notifies its listener.                   |
-| `WriteToSelfLog`                         | Log to `SelfLog`, then rethrow.                                           |
+| *(default: `Ignore`)*                    | Rethrow. `BatchingSink` catches, notifies its listener. **(CHANGED — was silent swallow.)** |
+| `WriteToSelfLog`                         | Log to `SelfLog`, then rethrow. **(CHANGED — was log-and-swallow.)**      |
 | `WriteToFailureSink` *(legacy routing)*  | Emit events to the configured failure sink, **do not rethrow** (unchanged). |
 | `WriteToFailureSink | WriteToSelfLog`    | Log + emit, **do not rethrow** (unchanged).                               |
 | `ThrowException`                         | Rethrow (unchanged).                                                      |

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/EmitEventFailureHandling.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/EmitEventFailureHandling.cs
@@ -18,26 +18,39 @@ namespace Serilog.Sinks.RabbitMQ;
 /// Specifies options for handling failures when emitting the events to RabbitMQ.
 /// Can be a combination of options.
 /// </summary>
+/// <remarks>
+/// These flags apply to the batched pipeline used by <c>WriteTo.RabbitMQ(...)</c>.
+/// The audit path (<c>AuditTo.RabbitMQ(...)</c>) always propagates publish exceptions —
+/// <see cref="WriteToFailureSink"/> and <see cref="WriteToSelfLog"/> have no effect there
+/// because audit semantics require failures to surface to the caller.
+/// </remarks>
 [Flags]
 public enum EmitEventFailureHandling
 {
     /// <summary>
-    /// Ignore the failure and continue.
+    /// Let publish exceptions propagate to the surrounding pipeline (for
+    /// <c>WriteTo.RabbitMQ</c>, that is <c>BatchingSink</c>'s
+    /// <see cref="Serilog.Core.ILoggingFailureListener"/> machinery). This is the default
+    /// and composes with <c>WriteTo.Fallback(...)</c>.
     /// </summary>
     Ignore = 0,
 
     /// <summary>
-    /// Send the error to the <see cref="Debugging.SelfLog"/>.
+    /// Send the error to the <see cref="Debugging.SelfLog"/> before propagating.
     /// </summary>
     WriteToSelfLog = 1,
 
     /// <summary>
-    /// Write the events to another sink. Make sure to configure this one.
+    /// Legacy: catch publish exceptions and emit the failed events to a separately-configured
+    /// failure sink. The exception is not propagated unless combined with
+    /// <see cref="ThrowException"/>. Consider <c>WriteTo.Fallback(...)</c> for new code.
     /// </summary>
     WriteToFailureSink = 2,
 
     /// <summary>
-    /// Throw the exception to the caller.
+    /// Force the publish exception to be rethrown even when combined with
+    /// <see cref="WriteToFailureSink"/>. Redundant on its own — the default path
+    /// already rethrows.
     /// </summary>
     ThrowException = 4,
 }

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -250,6 +250,10 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, ISetLogg
     /// </summary>
     /// <param name="events">Log events associated with the failure.</param>
     /// <param name="ex">Original publish exception.</param>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "A throwing failure listener must not recurse or break the sink; swallow and log to SelfLog. The original publish exception is propagated by the caller.")]
     private void NotifyListener(IReadOnlyCollection<LogEvent> events, Exception ex)
     {
         try

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -99,8 +99,13 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, ISetLogg
         }
         catch (Exception ex) when (_failureListener is not null)
         {
-            // Audit path: notify the listener before propagating so a Fallback-wrapped
-            // audit pipeline sees the failed event. Preserves audit semantics by rethrowing.
+            // The `when (_failureListener is not null)` filter above means this catch frame
+            // is not entered at all when no listener is registered — the exception propagates
+            // with its original stack intact, and we avoid the LogEvent[] allocation on the
+            // hot no-listener path.
+            //
+            // Audit path: notify the listener before propagating so a Fallback-wrapped audit
+            // pipeline sees the failed event. The `throw;` below preserves the original stack.
             NotifyListener(new[] { logEvent }, ex);
             throw;
         }

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -25,7 +25,7 @@ namespace Serilog.Sinks.RabbitMQ;
 /// <summary>
 /// Serilog RabbitMQ Sink - lets you log to RabbitMQ using Serilog.
 /// </summary>
-public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposable
+public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, ISetLoggingFailureListener, IDisposable
 {
     private static readonly RecyclableMemoryStreamManager _manager = new();
     private static readonly Encoding _utf8NoBOM = new UTF8Encoding(false);
@@ -37,6 +37,7 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
     private readonly ISendMessageEvents _sendMessageEvents;
     private readonly bool _persistent;
     private readonly string _routingKey;
+    private ILoggingFailureListener? _failureListener;
     private bool _disposedValue;
 
     /// <summary>
@@ -90,7 +91,34 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
     }
 
     /// <inheritdoc cref="ILogEventSink.Emit" />
-    public void Emit(LogEvent logEvent) => AsyncHelpers.RunSync(() => EmitAsync(logEvent));
+    public void Emit(LogEvent logEvent)
+    {
+        try
+        {
+            AsyncHelpers.RunSync(() => EmitAsync(logEvent));
+        }
+        catch (Exception ex) when (_failureListener is not null)
+        {
+            // Audit path: notify the listener before propagating so a Fallback-wrapped
+            // audit pipeline sees the failed event. Preserves audit semantics by rethrowing.
+            NotifyListener(new[] { logEvent }, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetFailureListener(ILoggingFailureListener failureListener)
+    {
+        // Per ISetLoggingFailureListener contract this is called once during
+        // initialization on the init thread, before logging starts. Plain field
+        // assignment is sufficient; no synchronisation required.
+        //
+        // Note: for the batched pipeline (WriteTo.RabbitMQ) Serilog's BatchingSink
+        // receives the listener and does not forward it — so _failureListener stays
+        // null there and the native BatchingSink handling does the work. This matters
+        // for the audit path (AuditTo.RabbitMQ) and for direct-construct users.
+        _failureListener = failureListener;
+    }
 
     /// <inheritdoc cref="IBatchedLogEventSink.EmitBatchAsync" />
     public async Task EmitBatchAsync(IReadOnlyCollection<LogEvent> batch)
@@ -165,7 +193,13 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
     /// </summary>
     /// <param name="ex">Occurred exception.</param>
     /// <param name="events">Batch of log events.</param>
-    /// <returns>true when exception has been handled.</returns>
+    /// <returns>
+    /// <see langword="true"/> when the exception has been fully handled and must not be
+    /// rethrown (legacy catch-and-route). <see langword="false"/> when the caller should
+    /// rethrow so Serilog's <see cref="IBatchedLogEventSink"/> pipeline (typically
+    /// <c>BatchingSink</c>) observes the failure and routes it through its own listener
+    /// machinery — this is how <c>WriteTo.Fallback(...)</c> composes.
+    /// </returns>
     private bool HandleException(Exception ex, LogEvent[] events)
     {
         if (_emitEventFailureHandling.HasFlag(EmitEventFailureHandling.WriteToSelfLog))
@@ -193,7 +227,39 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, IDisposa
             }
         }
 
-        // Return true if the exception has been handled. e.g. when the exception doesn't need to be rethrown.
-        return !_emitEventFailureHandling.HasFlag(EmitEventFailureHandling.ThrowException);
+        // Rethrow unless the user has opted into the legacy catch-and-route path
+        // (WriteToFailureSink) without also forcing ThrowException. Default — and every
+        // combination that does not set WriteToFailureSink — propagates the exception so
+        // BatchingSink's listener plumbing observes it. WriteToFailureSink + ThrowException
+        // is the explicit "route to failure sink AND still throw" combination.
+        bool legacyCatchOnly = _emitEventFailureHandling.HasFlag(EmitEventFailureHandling.WriteToFailureSink)
+                            && !_emitEventFailureHandling.HasFlag(EmitEventFailureHandling.ThrowException);
+        return legacyCatchOnly;
+    }
+
+    /// <summary>
+    /// Notifies the Serilog 4.1+ <see cref="ILoggingFailureListener"/> that a publish has
+    /// failed. Only meaningful for the sync <see cref="Emit(LogEvent)"/> audit path — the
+    /// batched pipeline routes failures through <c>BatchingSink</c>'s own listener, which
+    /// <see cref="ISetLoggingFailureListener"/> does not forward to inner sinks.
+    /// </summary>
+    /// <param name="events">Log events associated with the failure.</param>
+    /// <param name="ex">Original publish exception.</param>
+    private void NotifyListener(IReadOnlyCollection<LogEvent> events, Exception ex)
+    {
+        try
+        {
+            _failureListener!.OnLoggingFailed(
+                this,
+                LoggingFailureKind.Permanent,
+                "RabbitMQ publish failed.",
+                events,
+                ex);
+        }
+        catch (Exception exListener)
+        {
+            // A throwing listener must not recurse; drop to SelfLog and continue.
+            SelfLog.WriteLine("Failure listener threw: {0}", exListener);
+        }
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
@@ -102,12 +102,13 @@ namespace Serilog.Sinks.RabbitMQ
         NonDurable = 1,
         Durable = 2,
     }
-    public sealed class RabbitMQSink : Serilog.Core.IBatchedLogEventSink, Serilog.Core.ILogEventSink, System.IDisposable
+    public sealed class RabbitMQSink : Serilog.Core.IBatchedLogEventSink, Serilog.Core.ILogEventSink, Serilog.Core.ISetLoggingFailureListener, System.IDisposable
     {
         public void Dispose() { }
         public void Emit(Serilog.Events.LogEvent logEvent) { }
         public System.Threading.Tasks.Task EmitBatchAsync(System.Collections.Generic.IReadOnlyCollection<Serilog.Events.LogEvent> batch) { }
         public System.Threading.Tasks.Task OnEmptyBatchAsync() { }
+        public void SetFailureListener(Serilog.Core.ILoggingFailureListener failureListener) { }
     }
     public class RabbitMQSinkConfiguration
     {

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -384,6 +384,38 @@ public class RabbitMQSinkTests
     }
 
     [Fact]
+    public async Task EmitBatchAsync_ShouldLogToSelfLogAndEmitToFailureSinkWithoutRethrowing_WhenWriteToFailureSinkAndWriteToSelfLogAreCombined()
+    {
+        // Pins the WriteToFailureSink | WriteToSelfLog row of the behaviour matrix: both
+        // the SelfLog entry and the per-event emit to the failure sink run, and the
+        // exception is swallowed (WriteToFailureSink suppresses the rethrow).
+        var selfLogStringBuilder = new StringBuilder();
+        var writer = new StringWriter(selfLogStringBuilder);
+        SelfLog.Enable(writer);
+
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+        var rabbitMQClient = Substitute.For<IRabbitMQClient>();
+        rabbitMQClient.When(x => x.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>()))
+            .Do(_ => throw new InvalidOperationException("publish-fail"));
+
+        var failureSink = Substitute.For<ILogEventSink>();
+        var sut = new RabbitMQSink(
+            rabbitMQClient,
+            textFormatter,
+            messageEvents,
+            EmitEventFailureHandling.WriteToSelfLog | EmitEventFailureHandling.WriteToFailureSink,
+            failureSink);
+
+        var logEvent = LogEventBuilder.Create().Build();
+        var act = () => sut.EmitBatchAsync([logEvent]);
+
+        await Should.NotThrowAsync(act);
+        selfLogStringBuilder.Length.ShouldBeGreaterThan(0);
+        failureSink.Received(1).Emit(logEvent);
+    }
+
+    [Fact]
     public async Task EmitBatchAsync_ShouldRouteToFailureSinkAndStillRethrow_WhenWriteToFailureSinkIsCombinedWithThrowException()
     {
         // The combination "route events to my failure sink AND still throw" — covers users
@@ -499,7 +531,7 @@ public class RabbitMQSinkTests
     }
 
     [Fact]
-    public void Emit_Audit_DoesNotBreak_WhenListenerItselfThrows()
+    public void Emit_Audit_SwallowsListenerException_AndStillRethrowsOriginal()
     {
         // A throwing listener must be swallowed (SelfLog entry) without recursing; the
         // original publish exception still propagates.

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -256,9 +256,11 @@ public class RabbitMQSinkTests
     }
 
     [Fact]
-    public async Task EmitBatchAsync_ShouldWriteExceptionToSelfLog_WhenPublishThrowsException()
+    public async Task EmitBatchAsync_ShouldWriteExceptionToSelfLogAndRethrow_WhenPublishThrowsException()
     {
-        // Arrange
+        // Arrange — WriteToSelfLog logs to SelfLog first, then rethrows so BatchingSink
+        // (or any Fallback wrapper) can route the failure via its own listener plumbing.
+        // Previously the flag also caused silent swallow; that default no longer applies.
         var selfLogStringBuilder = new StringBuilder();
         var writer = new StringWriter(selfLogStringBuilder);
         SelfLog.Enable(writer);
@@ -275,9 +277,11 @@ public class RabbitMQSinkTests
         // Act
         var logEvent1 = LogEventBuilder.Create().Build();
         var logEvent2 = LogEventBuilder.Create().Build();
-        await sut.EmitBatchAsync([logEvent1, logEvent2]);
+        var act = () => sut.EmitBatchAsync([logEvent1, logEvent2]);
 
         // Assert
+        var thrown = await Should.ThrowAsync<Exception>(act);
+        thrown.Message.ShouldBe("some-message");
         selfLogStringBuilder.Length.ShouldBeGreaterThan(0);
         failureSink.Received(0).Emit(Arg.Any<LogEvent>());
     }
@@ -337,9 +341,12 @@ public class RabbitMQSinkTests
     }
 
     [Fact]
-    public async Task EmitBatchAsync_ShouldNotThrowException_WhenPublishThrowsException()
+    public async Task EmitBatchAsync_ShouldNotThrow_WhenWriteToFailureSinkIsConfigured()
     {
-        // Arrange
+        // After the 9.0 alignment with Serilog's BatchingSink model, WriteToFailureSink is
+        // the only flag combination that suppresses the exception. Everything else (default
+        // Ignore, WriteToSelfLog alone, ThrowException) rethrows so BatchingSink can route
+        // through its listener plumbing.
         var textFormatter = Substitute.For<ITextFormatter>();
         var messageEvents = Substitute.For<ISendMessageEvents>();
         var rabbitMQClient = Substitute.For<IRabbitMQClient>();
@@ -347,14 +354,59 @@ public class RabbitMQSinkTests
             .Do(_ => throw new Exception("some-message"));
 
         var failureSink = Substitute.For<ILogEventSink>();
-        var sut = new RabbitMQSink(rabbitMQClient, textFormatter, messageEvents, EmitEventFailureHandling.Ignore, failureSink);
+        var sut = new RabbitMQSink(rabbitMQClient, textFormatter, messageEvents, EmitEventFailureHandling.WriteToFailureSink, failureSink);
 
-        // Act
         var logEvent1 = LogEventBuilder.Create().Build();
         var act = () => sut.EmitBatchAsync([logEvent1]);
 
-        // Assert
         await Should.NotThrowAsync(act);
+    }
+
+    [Fact]
+    public async Task EmitBatchAsync_ShouldRethrow_WhenHandlingIsIgnoreAndPublishFails()
+    {
+        // Default handling (Ignore) now propagates publish failures so BatchingSink sees
+        // them. This is the behaviour change that makes WriteTo.Fallback(...) work for
+        // the batched pipeline.
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+        var rabbitMQClient = Substitute.For<IRabbitMQClient>();
+        rabbitMQClient.When(x => x.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>()))
+            .Do(_ => throw new InvalidOperationException("publish-fail"));
+
+        var sut = new RabbitMQSink(rabbitMQClient, textFormatter, messageEvents, EmitEventFailureHandling.Ignore);
+
+        var logEvent = LogEventBuilder.Create().Build();
+        var act = () => sut.EmitBatchAsync([logEvent]);
+
+        var thrown = await Should.ThrowAsync<InvalidOperationException>(act);
+        thrown.Message.ShouldBe("publish-fail");
+    }
+
+    [Fact]
+    public async Task EmitBatchAsync_ShouldRouteToFailureSinkAndStillRethrow_WhenWriteToFailureSinkIsCombinedWithThrowException()
+    {
+        // The combination "route events to my failure sink AND still throw" — covers users
+        // who want legacy routing AND want BatchingSink's listener to fire too.
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+        var rabbitMQClient = Substitute.For<IRabbitMQClient>();
+        rabbitMQClient.When(x => x.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>()))
+            .Do(_ => throw new InvalidOperationException("publish-fail"));
+
+        var failureSink = Substitute.For<ILogEventSink>();
+        var sut = new RabbitMQSink(
+            rabbitMQClient,
+            textFormatter,
+            messageEvents,
+            EmitEventFailureHandling.WriteToFailureSink | EmitEventFailureHandling.ThrowException,
+            failureSink);
+
+        var logEvent = LogEventBuilder.Create().Build();
+        var act = () => sut.EmitBatchAsync([logEvent]);
+
+        await Should.ThrowAsync<InvalidOperationException>(act);
+        failureSink.Received(1).Emit(logEvent);
     }
 
     [Fact]
@@ -400,5 +452,71 @@ public class RabbitMQSinkTests
     {
         LoggerAuditSinkConfiguration config = null!;
         Should.Throw<ArgumentNullException>(() => config.RabbitMQ((_, _) => { })).ParamName.ShouldBe("loggerAuditSinkConfiguration");
+    }
+
+    private static IRabbitMQClient ClientThatFailsPublish(string message = "publish-fail")
+    {
+        var client = Substitute.For<IRabbitMQClient>();
+        client.When(x => x.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>()))
+            .Do(_ => throw new InvalidOperationException(message));
+        return client;
+    }
+
+    private static RabbitMQSink CreateSut(IRabbitMQClient rabbitMQClient)
+        => new(
+            rabbitMQClient,
+            Substitute.For<ITextFormatter>(),
+            Substitute.For<ISendMessageEvents>());
+
+    [Fact]
+    public void Emit_Audit_NotifiesListenerAndRethrows_WhenPublishFails()
+    {
+        // Audit path: Fallback wrappers directly set the listener on RabbitMQSink (there
+        // is no BatchingSink in between). Listener fires, exception still propagates so
+        // audit semantics ("throw on failure") are preserved.
+        var listener = Substitute.For<ILoggingFailureListener>();
+        var sut = CreateSut(ClientThatFailsPublish());
+        sut.SetFailureListener(listener);
+
+        var logEvent = LogEventBuilder.Create().Build();
+        Should.Throw<InvalidOperationException>(() => sut.Emit(logEvent));
+
+        listener.Received(1).OnLoggingFailed(
+            sut,
+            LoggingFailureKind.Permanent,
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlyCollection<LogEvent>>(e => e.Count == 1 && e.Single() == logEvent),
+            Arg.Is<Exception>(e => e is InvalidOperationException && e.Message == "publish-fail"));
+    }
+
+    [Fact]
+    public void Emit_Audit_RethrowsWithoutNotification_WhenListenerIsNotSet()
+    {
+        // Baseline: audit path without a listener still rethrows; no extra handling runs.
+        var sut = CreateSut(ClientThatFailsPublish());
+
+        Should.Throw<InvalidOperationException>(() => sut.Emit(LogEventBuilder.Create().Build()));
+    }
+
+    [Fact]
+    public void Emit_Audit_DoesNotBreak_WhenListenerItselfThrows()
+    {
+        // A throwing listener must be swallowed (SelfLog entry) without recursing; the
+        // original publish exception still propagates.
+        var listener = Substitute.For<ILoggingFailureListener>();
+        listener.When(x => x.OnLoggingFailed(
+                Arg.Any<object>(),
+                Arg.Any<LoggingFailureKind>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyCollection<LogEvent>>(),
+                Arg.Any<Exception>()))
+            .Do(_ => throw new InvalidOperationException("listener-fail"));
+
+        var sut = CreateSut(ClientThatFailsPublish());
+        sut.SetFailureListener(listener);
+
+        // Original publish-fail propagates, NOT the listener-fail.
+        var thrown = Should.Throw<InvalidOperationException>(() => sut.Emit(LogEventBuilder.Create().Build()));
+        thrown.Message.ShouldBe("publish-fail");
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -390,7 +390,7 @@ public class RabbitMQSinkTests
         // the SelfLog entry and the per-event emit to the failure sink run, and the
         // exception is swallowed (WriteToFailureSink suppresses the rethrow).
         var selfLogStringBuilder = new StringBuilder();
-        var writer = new StringWriter(selfLogStringBuilder);
+        using var writer = new StringWriter(selfLogStringBuilder);
         SelfLog.Enable(writer);
 
         var textFormatter = Substitute.For<ITextFormatter>();


### PR DESCRIPTION
Fixes #293.

## Summary

Serilog's `BatchingSink` owns failure handling for the batched pipeline — it catches exceptions from `IBatchedLogEventSink.EmitBatchAsync` and routes them through an `ILoggingFailureListener` that `WriteTo.Fallback(...)` registers. Our sink was bypassing that machinery by catching every publish exception internally, so `WriteTo.Fallback(...)` could never see the failure.

This change makes `EmitBatchAsync` propagate by default. The legacy `EmitEventFailureHandling.WriteToFailureSink` path keeps its catch-and-route behaviour as an opt-in.

## Behaviour matrix

| Flags set                                | Behaviour                                                                                 |
|------------------------------------------|-------------------------------------------------------------------------------------------|
| *(default: `Ignore`)*                    | Rethrow. `BatchingSink` catches, notifies its listener.                                   |
| `WriteToSelfLog`                         | Log to `SelfLog`, then rethrow.                                                           |
| `WriteToFailureSink` *(legacy routing)*  | Emit events to the configured failure sink, **do not rethrow** (unchanged).               |
| `WriteToFailureSink | WriteToSelfLog`    | Log + emit, **do not rethrow** (unchanged).                                               |
| `ThrowException`                         | Rethrow (unchanged).                                                                      |
| `WriteToFailureSink | ThrowException`   | Emit events to the failure sink **and** rethrow.                                          |

## Behaviour change (documented in CHANGELOG)

Users on the `Ignore` default who did not wire `failureSinkConfiguration` previously saw silent failures. Publish errors now surface via `BatchingSink`'s default listener (`SelfLog`), or via the listener set by a `WriteTo.Fallback(...)` wrapper. Consider this an observability upgrade — silent logging failures are almost always undesirable. To preserve the old silent behaviour, set `emitEventFailure = WriteToFailureSink` and wire `failureSinkConfiguration` to a no-op sink.

## Audit path

`RabbitMQSink` also implements `ISetLoggingFailureListener` directly — this is only meaningful for the audit path (`AuditTo.RabbitMQ`) and direct-construct users, because `BatchingSink` does not forward `SetFailureListener` to its inner sink (by design). For the batched pipeline, `BatchingSink`'s own listener does the routing; our implementation is inert there.

The audit `Emit(LogEvent)` path notifies the listener before rethrowing, preserving audit semantics. A throwing listener is swallowed (`SelfLog` entry) and the original publish exception still propagates.

## Why not implement on `RabbitMQSink` for the batched pipeline?

`BatchingSink.SetFailureListener` stores the listener for its own use and does **not** forward it to the wrapped inner sink. Attempting to work around this by self-handling failures inside `RabbitMQSink` would either double-notify (both BatchingSink's listener and ours fire) or bypass BatchingSink's built-in retry/drop scheduling. The correct Serilog-native composition is: inner sink throws, BatchingSink handles. This PR aligns us with that model.

An earlier attempt (#292, closed) tried to implement the listener directly on `RabbitMQSink` for the batched pipeline. That was dead code — reading `BatchingSink.cs` in the Serilog repo confirmed the listener is not forwarded.

## Test plan

- [x] `dotnet build -c Release --no-restore` — all TFMs.
- [x] Unit tests on net10.0 × 3 consecutive runs — 83/83 stable. net8.0 — 82/82.
- [x] Integration tests — 26/26 on net10.0 against docker-compose brokers.
- [x] `dotnet format --verify-no-changes --severity warn` — clean.
- [x] Coverage — 100% on every new and modified method (`Emit`, `SetFailureListener`, `HandleException`, `NotifyListener`).
- [x] Public API approval snapshot regenerated — two new lines (interface + method).
- [x] Windows CI validates net48.

## API surface

Additive:

```csharp
public sealed class RabbitMQSink
    : IBatchedLogEventSink,
      ILogEventSink,
      ISetLoggingFailureListener,   // new
      IDisposable
{
    public void SetFailureListener(ILoggingFailureListener failureListener) { }  // new
    // ... existing members unchanged ...
}
```

## Deprecation is deferred

`EmitEventFailureHandling.WriteToFailureSink` and `failureSinkConfiguration` are **not** deprecated here. `Serilog.Settings.Configuration` does not yet support declarative `Fallback` configuration — appsettings.json users would have no migration path. Once upstream support lands, a follow-up will `[Obsolete]` the legacy parameter with a concrete migration example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)