### PR TITLE
Post-9.0.0 docs and naming cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Before `git commit`:
 3. `dotnet format --no-restore --verify-no-changes --severity warn` — CI gate.
 4. **Code coverage** on any method you added or modified in `src/` — see the coverlet command above. Zero uncovered lines/branches on new code.
 5. For integration-test-touching changes: run integration tests on net10.0 against the docker-compose brokers.
+6. **Update [CHANGELOG.md](CHANGELOG.md) and [README.md](README.md) whenever the change is user-visible** — new/changed/removed public API, behaviour changes, new configuration options, migration notes, or anything a consumer would need to read about before upgrading. Pure internals / test-only changes don't require updates, but default to updating when in doubt. For breaking changes, extend the `Migrating to X.Y.Z` section in README.
 
 Skipping step 4 has repeatedly meant shipping a commit, watching Codecov flag it, then following up. Don't.
 

--- a/README.md
+++ b/README.md
@@ -241,13 +241,44 @@ and ignore them.
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `emitEventFailure` | `EmitEventFailureHandling` | `WriteToSelfLog` | Combination of `Ignore`, `WriteToSelfLog`, `WriteToFailureSink`, `ThrowException`. |
-| `failureSinkConfiguration` | `Action<LoggerSinkConfiguration>?` | `null` | Sink(s) that receive events when the primary sink fails. Used together with `WriteToFailureSink`. |
+| `emitEventFailure` | `EmitEventFailureHandling` | `WriteToSelfLog` | Combination of `Ignore`, `WriteToSelfLog`, `WriteToFailureSink`, `ThrowException`. See behaviour table below. |
+| `failureSinkConfiguration` | `Action<LoggerSinkConfiguration>?` | `null` | Legacy sink(s) that receive events when the primary sink fails. Used together with `WriteToFailureSink`. Prefer `WriteTo.Fallback(...)` for new code. |
 | `formatter` | `ITextFormatter?` | `CompactJsonFormatter` | Formatter used to render the event into the message body. |
 | `levelSwitch` | `LogEventLevel` | `Verbose` | Minimum level for events emitted by the sink. |
 | `sendMessageEvents` | `ISendMessageEvents?` | `null` | Hooks for customising message properties and routing keys (see below). |
 
-Example with a console failure sink:
+`WriteTo.RabbitMQ` runs inside Serilog's `BatchingSink`. When a batch fails, the sink's behaviour depends on `emitEventFailure`:
+
+| Flags | Behaviour |
+|---|---|
+| `Ignore` | Rethrow. BatchingSink's failure listener observes the exception (defaults to `SelfLog`). |
+| `WriteToSelfLog` (default) | Log to `SelfLog`, then rethrow. |
+| `ThrowException` | Rethrow (same as `Ignore`; kept for clarity). |
+| `WriteToFailureSink` | Route events to the legacy failure sink; do **not** rethrow. |
+| `WriteToFailureSink \| WriteToSelfLog` | Log and route to failure sink; do not rethrow. |
+| `WriteToFailureSink \| ThrowException` | Route to failure sink **and** rethrow. |
+
+#### Recommended: `WriteTo.Fallback(...)` (Serilog 4.1+)
+
+For new code, use Serilog's native fallback chain instead of `failureSinkConfiguration`:
+
+```csharp
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Fallback(
+        primary => primary.RabbitMQ((client, sink) =>
+        {
+            client.Hostnames = ["localhost"];
+            client.Username  = "guest";
+            client.Password  = "guest";
+            client.Exchange  = "logs";
+        }),
+        fallback => fallback.Console())
+    .CreateLogger();
+```
+
+Leave `emitEventFailure` at its default — the fallback chain relies on the sink rethrowing.
+
+#### Legacy: `failureSinkConfiguration`
 
 ```csharp
 Log.Logger = new LoggerConfiguration()
@@ -371,6 +402,23 @@ and integration tests.
   in the background at startup. When all channels are in use, additional publish calls
   await until one is returned (previous behaviour grew the pool on demand). Broken channels
   are replaced automatically in the background.
+- **Failure handling aligns with Serilog's `BatchingSink`.** `EmitBatchAsync` now rethrows
+  by default so the BatchingSink's failure listener observes the error (it writes to
+  `SelfLog` unless a listener is configured). Previously, failures were swallowed when
+  `WriteToFailureSink` was not set. If you relied on the old silent behaviour, set
+  `emitEventFailure` to `WriteToFailureSink` with a `failureSinkConfiguration`, or wire a
+  `WriteTo.Fallback(...)` chain. `AuditTo.RabbitMQ` also notifies any configured
+  `ILoggingFailureListener` before rethrowing.
+- **`WriteTo.Fallback(...)` is now the recommended pattern.** Serilog 4.1's native fallback
+  chain is preferred over `failureSinkConfiguration`. See the [Failure handling](#failure-handling)
+  section.
+- **`Validate()` on configuration objects.** `RabbitMQClientConfiguration` and
+  `RabbitMQSinkConfiguration` now expose public `Validate()` methods and are invoked during
+  sink construction. Misconfiguration (missing hostnames, invalid port, zero batch limit,
+  etc.) throws at startup instead of failing at first publish.
+- **`QueueLimit` validation.** `QueueLimit`, when set, must be greater than zero —
+  `QueueLimit = 0` now throws `ArgumentOutOfRangeException` rather than silently creating a
+  zero-capacity queue. Leave the property unset (`null`) for an unbounded queue.
 - **`Microsoft.Extensions.ObjectPool` dependency removed.** No action needed unless your
   application referenced it transitively through this package.
 - **Target frameworks:** `net6.0` and `net9.0` were removed. Supported targets are

--- a/src/Serilog.Sinks.RabbitMQ/LoggerConfigurationRabbitMQExtensions.cs
+++ b/src/Serilog.Sinks.RabbitMQ/LoggerConfigurationRabbitMQExtensions.cs
@@ -36,7 +36,7 @@ public static class LoggerConfigurationRabbitMQExtensions
     /// <summary>
     /// Default value for the time to wait between checking for event batches.
     /// </summary>
-    internal static readonly TimeSpan _defaultBufferingTimeLimit = TimeSpan.FromSeconds(2);
+    internal static readonly TimeSpan DEFAULT_BUFFERING_TIME_LIMIT = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Adds a sink that lets you push log messages to RabbitMQ.
@@ -167,7 +167,7 @@ public static class LoggerConfigurationRabbitMQExtensions
         var sinkConfiguration = new RabbitMQSinkConfiguration
         {
             BatchPostingLimit = batchPostingLimit == default ? DEFAULT_BATCH_POSTING_LIMIT : batchPostingLimit,
-            BufferingTimeLimit = bufferingTimeLimit == default ? _defaultBufferingTimeLimit : bufferingTimeLimit,
+            BufferingTimeLimit = bufferingTimeLimit == default ? DEFAULT_BUFFERING_TIME_LIMIT : bufferingTimeLimit,
             QueueLimit = queueLimit,
             EmitEventFailure = emitEventFailure,
             RestrictedToMinimumLevel = levelSwitch,
@@ -325,7 +325,7 @@ public static class LoggerConfigurationRabbitMQExtensions
             : sinkConfiguration.BatchPostingLimit;
 
         sinkConfiguration.BufferingTimeLimit = sinkConfiguration.BufferingTimeLimit == default
-            ? _defaultBufferingTimeLimit
+            ? DEFAULT_BUFFERING_TIME_LIMIT
             : sinkConfiguration.BufferingTimeLimit;
 
         clientConfiguration.Validate();

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/IRabbitMQConnectionFactory.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/IRabbitMQConnectionFactory.cs
@@ -22,9 +22,11 @@ namespace Serilog.Sinks.RabbitMQ;
 internal interface IRabbitMQConnectionFactory : IAsyncDisposable
 {
     /// <summary>
-    /// Returns the connection. Creates a new connection if none exists.
+    /// Returns the cached <see cref="IConnection"/>, creating it on the first call.
+    /// Subsequent calls return the same instance. Creation is gated internally so
+    /// concurrent callers see a single connection.
     /// </summary>
-    /// <returns>New or already created connection.</returns>
+    /// <returns>The shared, lazily-created connection.</returns>
     Task<IConnection> GetConnectionAsync();
 
     /// <summary>

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -26,7 +26,7 @@ namespace Serilog.Sinks.RabbitMQ;
 /// </summary>
 internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
 {
-    private static readonly TimeSpan WarmUpRetryDelay = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan WARM_UP_RETRY_DELAY = TimeSpan.FromMilliseconds(500);
 
     private readonly RabbitMQClientConfiguration _config;
     private readonly IRabbitMQConnectionFactory _connectionFactory;
@@ -194,7 +194,7 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                 SelfLog.WriteLine("Failed to warm up RabbitMQ channel: {0}", ex);
                 try
                 {
-                    await Task.Delay(WarmUpRetryDelay, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(WARM_UP_RETRY_DELAY, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSinkConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSinkConfiguration.cs
@@ -34,7 +34,7 @@ public class RabbitMQSinkConfiguration
     /// The time to wait between checking for event batches.
     /// Default is 2 seconds.
     /// </summary>
-    public TimeSpan BufferingTimeLimit { get; set; } = LoggerConfigurationRabbitMQExtensions._defaultBufferingTimeLimit;
+    public TimeSpan BufferingTimeLimit { get; set; } = LoggerConfigurationRabbitMQExtensions.DEFAULT_BUFFERING_TIME_LIMIT;
 
     /// <summary>
     /// The batched sink internal queue limit.


### PR DESCRIPTION
Closes #295.

Follow-up to #294 — documentation, naming, and process only. No behavioural or public-API changes.

## Summary

- Rename `_defaultBufferingTimeLimit` → `DEFAULT_BUFFERING_TIME_LIMIT` and `WarmUpRetryDelay` → `WARM_UP_RETRY_DELAY` to match the `UPPER_CASE` constant convention.
- Tighten `IRabbitMQConnectionFactory.GetConnectionAsync` XML doc — the previous wording left the caching/singleton semantics ambiguous.
- Rewrite README "Failure handling" section for the post-#294 model: per-flags behaviour table, `WriteTo.Fallback(...)` as the recommended pattern, `failureSinkConfiguration` framed as legacy.
- Expand "Migrating to 9.0.0" with bullets for `Validate()`, `QueueLimit > 0`, the failure-handling behaviour change, and `WriteTo.Fallback(...)`.
- CLAUDE.md pre-commit checklist: add explicit step to update README + CHANGELOG for user-visible changes.

## Test plan

- [x] `dotnet build -c Release --no-restore` — 0 warnings / 0 errors across `netstandard2.0`, `net8.0`, `net10.0`.
- [x] Unit tests on `net10.0` — 84 passed.
- [x] Unit tests on `net8.0` — 83 passed.
- [x] `dotnet format --no-restore --verify-no-changes --severity warn` — clean.
- [x] No `src/` logic changes; no new coverage surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)