### PR TITLE
Validate ChannelCount > 0 on RabbitMQClientConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,8 +213,15 @@ hand to a custom `RabbitMQSink`) can use it to get the same safety net that
 
 Existing client-configuration checks (non-empty hostnames, non-empty username,
 non-null password, valid port range) were moved verbatim — exception types and
-messages are preserved. `RabbitMQSinkConfiguration.Validate()` is new and
-additionally checks:
+messages are preserved. `RabbitMQClientConfiguration.Validate()` additionally
+checks:
+
+- `ChannelCount > 0` — **tightened constraint**: a zero or negative
+  `ChannelCount` was previously silently substituted with the default of 64
+  inside the channel pool; it is now rejected at configuration time. The
+  defensive clamp in the pool constructor has been removed.
+
+`RabbitMQSinkConfiguration.Validate()` is new and additionally checks:
 
 - `TextFormatter` is non-null
 - `BatchPostingLimit > 0`
@@ -242,6 +249,9 @@ renamed to `channelCount`. Update appsettings JSON / `App.config` keys from `max
 - `RabbitMQClientConfiguration.MaxChannels` is now `[Obsolete]`; use `ChannelCount`
 - `RabbitMQSinkConfiguration.QueueLimit` must be greater than zero when set; zero or
   negative values now throw `ArgumentOutOfRangeException` at configuration time
+- `RabbitMQClientConfiguration.ChannelCount` must be greater than zero; zero or
+  negative values now throw `ArgumentOutOfRangeException` at configuration time
+  (previously silently substituted with the default of 64)
 - `RabbitMQSink.EmitBatchAsync` propagates publish exceptions by default instead of
   silently swallowing them. Use `EmitEventFailureHandling.WriteToFailureSink` to keep
   legacy catch-and-route behaviour.

--- a/README.md
+++ b/README.md
@@ -419,6 +419,10 @@ and integration tests.
 - **`QueueLimit` validation.** `QueueLimit`, when set, must be greater than zero —
   `QueueLimit = 0` now throws `ArgumentOutOfRangeException` rather than silently creating a
   zero-capacity queue. Leave the property unset (`null`) for an unbounded queue.
+- **`ChannelCount` validation.** `ChannelCount` must be greater than zero. `ChannelCount = 0`
+  or a negative value now throws `ArgumentOutOfRangeException` at configuration time;
+  previously the channel pool silently substituted the default of 64. Omit the property (or
+  leave the parameter at its default) to keep the default pool size.
 - **`Microsoft.Extensions.ObjectPool` dependency removed.** No action needed unless your
   application referenced it transitively through this package.
 - **Target frameworks:** `net6.0` and `net9.0` were removed. Supported targets are

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -49,7 +49,7 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     {
         _config = configuration;
         _connectionFactory = connectionFactory;
-        _size = configuration.ChannelCount > 0 ? configuration.ChannelCount : RabbitMQClient.DEFAULT_CHANNEL_COUNT;
+        _size = configuration.ChannelCount;
         _channels = Channel.CreateBounded<IRabbitMQChannel>(_size);
 
         _ = Task.Run(() => WarmUpAsync(_size, _shutdownCts.Token));

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClientConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClientConfiguration.cs
@@ -146,7 +146,7 @@ public class RabbitMQClientConfiguration
     /// previously observed when the checks lived in <c>LoggerConfigurationRabbitMQExtensions</c>.
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <see cref="Hostnames"/> is null or empty, <see cref="Username"/> is null or empty, or <see cref="Password"/> is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="Port"/> is outside the valid TCP range.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="Port"/> is outside the valid TCP range or <see cref="ChannelCount"/> is not greater than zero.</exception>
     [SuppressMessage(
         "Major Code Smell",
         "S3928:Parameter names used into ArgumentException constructors should match an existing one",
@@ -171,6 +171,11 @@ public class RabbitMQClientConfiguration
         if (Port is < 0 or > 65535)
         {
             throw new ArgumentOutOfRangeException(nameof(Port), "port must be in a valid range (1 and 65535)");
+        }
+
+        if (ChannelCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ChannelCount), "ChannelCount must be greater than zero.");
         }
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -727,27 +727,6 @@ public class RabbitMQChannelPoolTests
     }
 
     [Fact]
-    public async Task Constructor_DefaultsToSixtyFourChannels_WhenChannelCountIsZero()
-    {
-        // Arrange
-        int created = 0;
-        var connection = BuildConnectionWithChannelFactory(() =>
-        {
-            Interlocked.Increment(ref created);
-            return CreateOpenChannel();
-        });
-        var connectionFactory = BuildConnectionFactory(connection);
-        var configuration = new RabbitMQClientConfiguration { ChannelCount = 0 };
-
-        // Act
-        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        await WaitForAsync(() => Volatile.Read(ref created) == 64);
-
-        // Assert
-        Volatile.Read(ref created).ShouldBe(64);
-    }
-
-    [Fact]
     public async Task ReturnAsync_AfterDispose_DisposesChannel()
     {
         // Arrange

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQClientConfigurationTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQClientConfigurationTests.cs
@@ -125,6 +125,17 @@ public class RabbitMQClientConfigurationTests
         Should.Throw<ArgumentOutOfRangeException>(sut.Validate).ParamName.ShouldBe("Port");
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_Throws_WhenChannelCountIsNotPositive(int channelCount)
+    {
+        var sut = ValidSample();
+        sut.ChannelCount = channelCount;
+
+        Should.Throw<ArgumentOutOfRangeException>(sut.Validate).ParamName.ShouldBe("ChannelCount");
+    }
+
     [Fact]
     public void Validate_IsIdempotent_WhenCalledRepeatedlyOnValidConfiguration()
     {


### PR DESCRIPTION
Closes #297.

## Summary

`RabbitMQSinkConfiguration.Validate()` already throws on `BatchPostingLimit <= 0`. The equivalent check for `ChannelCount` was missing: the channel pool constructor silently substituted the default (64) for any non-positive value, so the two sides of the same public configuration surface disagreed on whether an invalid positive-numeric value threw or was corrected. This PR tightens the behaviour to match.

## Changes

- **`RabbitMQClientConfiguration.Validate()`** — throws `ArgumentOutOfRangeException` with `ParamName = "ChannelCount"` when `ChannelCount <= 0`. Mirrors the `BatchPostingLimit` check on the sink side. The `[Obsolete]` `MaxChannels` forwarder inherits the check automatically.
- **`RabbitMQChannelPool` constructor** — drops the `ChannelCount > 0 ? ChannelCount : DEFAULT` clamp; assumes `Validate()` has already run. Direct callers that bypass validation will fail at the pool's `Channel.CreateBounded` call.
- **Tests**:
  - Added `Validate_Throws_WhenChannelCountIsNotPositive` theory (0, -1) to `RabbitMQClientConfigurationTests`.
  - Removed `Constructor_DefaultsToSixtyFourChannels_WhenChannelCountIsZero` from `RabbitMQChannelPoolTests` — it was pinning the clamp that's gone.
- **Docs** — CHANGELOG notes the tightened constraint under 9.0.0 (both the `Validate()` section and the Breaking changes list); README migration section adds a matching bullet alongside the existing `QueueLimit` entry.
- **Public API** — no shape change; `Validate()` already exists on the approved snapshot.

## Test plan

- [x] `dotnet build -c Release --no-restore` — 0 warnings / 0 errors across `netstandard2.0`, `net8.0`, `net10.0` (+ `net48` for tests).
- [x] Unit tests on `net10.0` — 85 passed (was 84; +2 theory cases, -1 removed test).
- [x] Unit tests on `net8.0` — 84 passed.
- [x] `dotnet format --no-restore --verify-no-changes --severity warn` — clean.
- [x] Coverage (`coverlet` / opencover) — touched methods (`Validate`, pool `.ctor`) have zero uncovered sequence points and zero uncovered branch points.
- [x] Public API approval snapshot — unchanged, `ApiApprovalTests` green.
- [x] Windows CI validates net48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)