### PR TITLE
Unit coverage for extensions + factory; SelfLog test hygiene

### DIFF
--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConnectionFactory.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQConnectionFactory.cs
@@ -122,7 +122,15 @@ internal sealed class RabbitMQConnectionFactory : IRabbitMQConnectionFactory
             Version = source.Version,
         };
 
-    private ConnectionFactory GetConnectionFactory()
+    /// <summary>
+    /// Builds the underlying <see cref="ConnectionFactory"/> from the configuration.
+    /// Exposed internally so tests can exercise each wiring branch (auth mechanism
+    /// selection, SSL, ClientProvidedName, Heartbeat, VHost, Port, Hostnames) without
+    /// a running broker. Each call constructs a fresh instance; callers outside the
+    /// constructor should treat the returned value as immutable configuration.
+    /// </summary>
+    /// <returns>A newly-constructed <see cref="ConnectionFactory"/>.</returns>
+    internal ConnectionFactory GetConnectionFactory()
     {
         // prepare connection factory
         var connectionFactory = new ConnectionFactory

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/LoggerConfigurationRabbitMQExtensionsTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/LoggerConfigurationRabbitMQExtensionsTests.cs
@@ -1,3 +1,8 @@
+using System.Net.Security;
+using System.Security.Authentication;
+using Serilog.Events;
+using Serilog.Formatting.Compact;
+
 namespace Serilog.Sinks.RabbitMQ.Tests;
 
 public class LoggerConfigurationRabbitMQExtensionsTests
@@ -10,6 +15,7 @@ public class LoggerConfigurationRabbitMQExtensionsTests
         Port = 5672,
         Exchange = "x",
         ExchangeType = "topic",
+        ChannelCount = 1,
     };
 
     private static RabbitMQSinkConfiguration ValidSinkConfiguration() => new()
@@ -70,5 +76,260 @@ public class LoggerConfigurationRabbitMQExtensionsTests
         Should.Throw<ArgumentException>(() =>
             loggerConfig.AuditTo.RabbitMQ(ValidClientConfiguration(), sinkConfig))
             .ParamName.ShouldBe("TextFormatter");
+    }
+
+    [Fact]
+    public void WriteTo_RabbitMQ_Delegate_Builds_AndAppliesCallerOverrides()
+    {
+        // The delegate overload lets the caller populate both configurations inline.
+        // Proves the delegate is invoked and the resulting configuration drives RegisterSink.
+        var delegateCalled = false;
+
+        using var logger = new LoggerConfiguration()
+            .WriteTo.RabbitMQ(
+                (client, sink) =>
+                {
+                    delegateCalled = true;
+                    client.Hostnames = ["localhost"];
+                    client.Username = "guest";
+                    client.Password = "guest";
+                    client.Exchange = "x";
+                    client.ExchangeType = "topic";
+                    client.ChannelCount = 1;
+                    sink.BatchPostingLimit = 25;
+                    sink.BufferingTimeLimit = TimeSpan.FromSeconds(1);
+                })
+            .CreateLogger();
+
+        delegateCalled.ShouldBeTrue();
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void WriteTo_RabbitMQ_WithFailureSinkConfiguration_Builds()
+    {
+        // Exercises the `failureSinkConfiguration != null` branch in RegisterSink —
+        // the wrapper sink path that routes failed events through the failure sink.
+        using var logger = new LoggerConfiguration()
+            .WriteTo.RabbitMQ(
+                ValidClientConfiguration(),
+                ValidSinkConfiguration(),
+                failureSinkConfiguration: fb => fb.Sink(Substitute.For<Core.ILogEventSink>()))
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void WriteTo_RabbitMQ_WithQueueLimit_Builds()
+    {
+        // Exercises the `sinkConfiguration.QueueLimit.HasValue` branch in
+        // GetPeriodicBatchingSink that forwards QueueLimit to BatchingOptions.
+        var sinkConfig = ValidSinkConfiguration();
+        sinkConfig.QueueLimit = 1000;
+
+        using var logger = new LoggerConfiguration()
+            .WriteTo.RabbitMQ(ValidClientConfiguration(), sinkConfig)
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void WriteTo_RabbitMQ_AppliesDefaults_WhenBatchingValuesAreDefault()
+    {
+        // Covers the default-substitution branches in RegisterSink (lines
+        // around BatchPostingLimit == default / BufferingTimeLimit == default).
+        // A caller who binds from appsettings with these omitted gets the
+        // property-initializer values; one who constructs a config and leaves
+        // the batch values at their CLR defaults gets the library defaults.
+        var sinkConfig = new RabbitMQSinkConfiguration
+        {
+            BatchPostingLimit = 0,
+            BufferingTimeLimit = TimeSpan.Zero,
+        };
+
+        using var logger = new LoggerConfiguration()
+            .WriteTo.RabbitMQ(ValidClientConfiguration(), sinkConfig)
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+        sinkConfig.BatchPostingLimit.ShouldBe(50);
+        sinkConfig.BufferingTimeLimit.ShouldBe(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void WriteTo_RabbitMQ_FlatOverload_Defaults_Builds()
+    {
+        // Happy path for the large parameter-list overload with only the required
+        // args. Exercises every null-coalescing (exchange / exchangeType / routingKey
+        // / vHost / sendMessageEvents) and the non-SSL / no-formatter branches.
+        using var logger = new LoggerConfiguration()
+            .WriteTo.RabbitMQ(
+                hostnames: ["localhost"],
+                username: "guest",
+                password: "guest",
+                channelCount: 1)
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void WriteTo_RabbitMQ_FlatOverload_AllOptions_Builds()
+    {
+        // Exercises every non-default branch of the flat overload: SSL on with
+        // explicit ServerName, non-null formatter, explicit strings for every
+        // optional, non-null sendMessageEvents.
+        using var logger = new LoggerConfiguration()
+            .WriteTo.RabbitMQ(
+                hostnames: ["localhost"],
+                username: "guest",
+                password: "guest",
+                exchange: "x",
+                exchangeType: "topic",
+                deliveryMode: RabbitMQDeliveryMode.Durable,
+                routingKey: "r",
+                port: 5672,
+                vHost: "/custom",
+                clientProvidedName: "unit-test",
+                heartbeat: 30,
+                sslEnabled: true,
+                sslServerName: "localhost",
+                sslVersion: SslProtocols.Tls12,
+                sslAcceptablePolicyErrors: SslPolicyErrors.RemoteCertificateNameMismatch,
+                sslCheckCertificateRevocation: true,
+                batchPostingLimit: 10,
+                bufferingTimeLimit: TimeSpan.FromSeconds(5),
+                queueLimit: 500,
+                formatter: new CompactJsonFormatter(),
+                autoCreateExchange: true,
+                channelCount: 2,
+                levelSwitch: LogEventLevel.Warning,
+                emitEventFailure: EmitEventFailureHandling.WriteToSelfLog,
+                failureSinkConfiguration: null,
+                sendMessageEvents: Substitute.For<ISendMessageEvents>())
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void WriteTo_RabbitMQ_FlatOverload_AppliesBatchPostingLimitDefault_WhenExplicitZero()
+    {
+        // Covers the `batchPostingLimit == default ? DEFAULT : batchPostingLimit` branch
+        // in the flat overload: an appsettings binding that passes 0 through the parameter
+        // should still end up with the library default (50), not create a zero-limit batch.
+        using var logger = new LoggerConfiguration()
+            .WriteTo.RabbitMQ(
+                hostnames: ["localhost"],
+                username: "guest",
+                password: "guest",
+                batchPostingLimit: 0,
+                channelCount: 1)
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void WriteTo_RabbitMQ_FlatOverload_SslEnabledWithoutServerName_DoesNotBuildSslOption()
+    {
+        // Documents existing behaviour: when sslEnabled is true but sslServerName is
+        // null, the flat overload does NOT construct an SslOption — effectively silently
+        // disabling SSL. Covers the `sslEnabled && sslServerName is not null` false path.
+        using var logger = new LoggerConfiguration()
+            .WriteTo.RabbitMQ(
+                hostnames: ["localhost"],
+                username: "guest",
+                password: "guest",
+                sslEnabled: true,
+                sslServerName: null,
+                channelCount: 1)
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AuditTo_RabbitMQ_Delegate_Builds_AndAppliesCallerOverrides()
+    {
+        var delegateCalled = false;
+
+        using var logger = new LoggerConfiguration()
+            .AuditTo.RabbitMQ(
+                (client, sink) =>
+                {
+                    delegateCalled = true;
+                    client.Hostnames = ["localhost"];
+                    client.Username = "guest";
+                    client.Password = "guest";
+                    client.ChannelCount = 1;
+                })
+            .CreateLogger();
+
+        delegateCalled.ShouldBeTrue();
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AuditTo_RabbitMQ_FlatOverload_Defaults_Builds()
+    {
+        using var logger = new LoggerConfiguration()
+            .AuditTo.RabbitMQ(
+                hostnames: ["localhost"],
+                username: "guest",
+                password: "guest",
+                channelCount: 1)
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AuditTo_RabbitMQ_FlatOverload_AllOptions_Builds()
+    {
+        using var logger = new LoggerConfiguration()
+            .AuditTo.RabbitMQ(
+                hostnames: ["localhost"],
+                username: "guest",
+                password: "guest",
+                exchange: "x",
+                exchangeType: "topic",
+                deliveryMode: RabbitMQDeliveryMode.Durable,
+                routingKey: "r",
+                port: 5672,
+                vHost: "/custom",
+                clientProvidedName: "unit-test-audit",
+                heartbeat: 30,
+                sslEnabled: true,
+                sslServerName: "localhost",
+                sslVersion: SslProtocols.Tls12,
+                sslAcceptablePolicyErrors: SslPolicyErrors.RemoteCertificateNameMismatch,
+                sslCheckCertificateRevocation: true,
+                formatter: new CompactJsonFormatter(),
+                autoCreateExchange: true,
+                channelCount: 1,
+                levelSwitch: LogEventLevel.Warning,
+                sendMessageEvents: Substitute.For<ISendMessageEvents>())
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AuditTo_RabbitMQ_FlatOverload_SslEnabledWithoutServerName_DoesNotBuildSslOption()
+    {
+        using var logger = new LoggerConfiguration()
+            .AuditTo.RabbitMQ(
+                hostnames: ["localhost"],
+                username: "guest",
+                password: "guest",
+                sslEnabled: true,
+                sslServerName: null,
+                channelCount: 1)
+            .CreateLogger();
+
+        logger.ShouldNotBeNull();
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/LoggerConfigurationRabbitMQExtensionsTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/LoggerConfigurationRabbitMQExtensionsTests.cs
@@ -5,6 +5,12 @@ using Serilog.Formatting.Compact;
 
 namespace Serilog.Sinks.RabbitMQ.Tests;
 
+// The flat-overload tests below construct real RabbitMQSink instances, which spawn a
+// background channel-pool warmup task. When no broker is reachable the warmup writes
+// "Failed to warm up RabbitMQ channel" to SelfLog. Joining the "SelfLog" collection
+// serialises these tests against the SelfLog-asserting tests in other classes so those
+// writes do not land in a sibling test's StringWriter (issue #282).
+[Collection("SelfLog")]
 public class LoggerConfigurationRabbitMQExtensionsTests
 {
     private static RabbitMQClientConfiguration ValidClientConfiguration() => new()

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -14,8 +14,11 @@
 
 using System.Diagnostics;
 
+using Serilog.Sinks.RabbitMQ.Tests.TestHelpers;
+
 namespace Serilog.Sinks.RabbitMQ.Tests.RabbitMQ;
 
+[Collection("SelfLog")]
 public class RabbitMQChannelPoolTests
 {
     private static IConnection BuildConnectionWithChannelFactory(Func<IChannel> channelFactory)
@@ -153,16 +156,15 @@ public class RabbitMQChannelPoolTests
     }
 
     [Fact]
-    public async Task ReturnAsync_WhenBrokenChannelDisposeThrows_StillRefillsPool()
+    public async Task ReturnAsync_WhenBrokenChannelDisposeThrows_StillRefillsPoolAndLogs()
     {
         // Arrange — the broken channel's DisposeAsync throws. The fire-and-forget
-        // replacement task must catch the exception (so it is not unobserved) and
-        // still run WarmUpAsync to refill the pool. Without the catch, the await
-        // would short-circuit the lambda and WarmUpAsync would never execute —
-        // WaitForAsync(created == 2) below would then hit its 2s timeout.
-        //
-        // The catch also logs to SelfLog, but asserting on SelfLog here is flaky:
-        // SelfLog is a global static and parallel test classes race for the writer.
+        // replacement task must catch the exception (so it is not unobserved),
+        // log it to SelfLog, and still run WarmUpAsync to refill the pool.
+        // [Collection("SelfLog")] serialises writers so the content assertion
+        // below is deterministic (issue #282).
+        using var selfLog = new SelfLogScope(out var selfLogBuilder);
+
         int created = 0;
         var connection = BuildConnectionWithChannelFactory(() =>
         {
@@ -182,9 +184,10 @@ public class RabbitMQChannelPoolTests
         // Act
         await pool.ReturnAsync(brokenChannel);
 
-        // Assert — the pool refills even though the broken channel's dispose threw.
+        // Assert — replacement still happens and SelfLog records the swallowed error.
         await WaitForAsync(() => Volatile.Read(ref created) == 2);
         await brokenChannel.Received(1).DisposeAsync();
+        selfLogBuilder.ToString().ShouldContain("dispose-boom");
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -1,12 +1,13 @@
 using Serilog.Configuration;
 using Serilog.Core;
-using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Compact;
+using Serilog.Sinks.RabbitMQ.Tests.TestHelpers;
 
 namespace Serilog.Sinks.RabbitMQ.Tests.RabbitMQ;
 
+[Collection("SelfLog")]
 public class RabbitMQSinkTests
 {
     private sealed class StubClient : IRabbitMQClient
@@ -172,14 +173,13 @@ public class RabbitMQSinkTests
         // AsyncHelpers.RunSync must fully isolate async continuations from the caller's
         // SynchronizationContext, otherwise Dispose() will deadlock under a single-threaded
         // UI-style context (WinForms/WPF). We install an outer context whose Post throws —
-        // any continuation routed through it is a bug in the sync-over-async bridge and
-        // the dispose thread would either fail to complete or hang.
-        //
-        // The primary contract — no deadlock — is proven by thread.Join(5s) below. An
-        // earlier version of this test also asserted that SelfLog stayed empty, but
-        // SelfLog is a global static and tests in parallel classes (e.g. the channel-
-        // pool warmup-retry tests) write to it; that assertion was inherently flaky. See
-        // issue #283 for the broader SelfLog parallel-class hygiene work.
+        // any continuation routed through it is a bug in the sync-over-async bridge, and
+        // Sink.Dispose swallows exceptions into SelfLog so we also capture SelfLog to
+        // detect silent regressions where the outer context got invoked. The
+        // [Collection("SelfLog")] attribute on this class serialises every SelfLog-touching
+        // test (issue #282) so the assertion below is not racy against parallel writers.
+        using var selfLog = new SelfLogScope(out var selfLogBuilder);
+
         var textFormatter = Substitute.For<ITextFormatter>();
         var messageEvents = Substitute.For<ISendMessageEvents>();
         var rabbitMQClient = new YieldingDisposeClient();
@@ -198,6 +198,7 @@ public class RabbitMQSinkTests
 
         disposeThread.Join(TimeSpan.FromSeconds(5)).ShouldBeTrue(
             "RabbitMQSink.Dispose deadlocked on a single-threaded SynchronizationContext.");
+        selfLogBuilder.ToString().ShouldBeEmpty();
         rabbitMQClient.DisposeAsyncCallCount.ShouldBe(1);
     }
 
@@ -261,9 +262,7 @@ public class RabbitMQSinkTests
         // Arrange — WriteToSelfLog logs to SelfLog first, then rethrows so BatchingSink
         // (or any Fallback wrapper) can route the failure via its own listener plumbing.
         // Previously the flag also caused silent swallow; that default no longer applies.
-        var selfLogStringBuilder = new StringBuilder();
-        var writer = new StringWriter(selfLogStringBuilder);
-        SelfLog.Enable(writer);
+        using var selfLog = new SelfLogScope(out var selfLogStringBuilder);
 
         var textFormatter = Substitute.For<ITextFormatter>();
         var messageEvents = Substitute.For<ISendMessageEvents>();
@@ -290,9 +289,7 @@ public class RabbitMQSinkTests
     public async Task EmitBatchAsync_ShouldWriteExceptionsToSelfLog_WhenFailureSinkThrowsException()
     {
         // Arrange
-        var selfLogStringBuilder = new StringBuilder();
-        var writer = new StringWriter(selfLogStringBuilder);
-        SelfLog.Enable(writer);
+        using var selfLog = new SelfLogScope(out var selfLogStringBuilder);
 
         var textFormatter = Substitute.For<ITextFormatter>();
         var messageEvents = Substitute.For<ISendMessageEvents>();
@@ -389,9 +386,7 @@ public class RabbitMQSinkTests
         // Pins the WriteToFailureSink | WriteToSelfLog row of the behaviour matrix: both
         // the SelfLog entry and the per-event emit to the failure sink run, and the
         // exception is swallowed (WriteToFailureSink suppresses the rethrow).
-        var selfLogStringBuilder = new StringBuilder();
-        using var writer = new StringWriter(selfLogStringBuilder);
-        SelfLog.Enable(writer);
+        using var selfLog = new SelfLogScope(out var selfLogStringBuilder);
 
         var textFormatter = Substitute.For<ITextFormatter>();
         var messageEvents = Substitute.For<ISendMessageEvents>();

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQConnectionFactoryTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQConnectionFactoryTests.cs
@@ -27,8 +27,11 @@ public class RabbitMQConnectionFactoryTests
         Password = "guest",
     };
 
-    private static RabbitMQConnectionFactory Build(RabbitMQClientConfiguration configuration) =>
-        new(configuration, new CancellationTokenSource());
+    // CTS ownership stays with the test (caller declares `using var cts`) so the native
+    // handle is released deterministically. Every call must pass a CTS — returning a
+    // factory with an undisposed CTS would leak one per test.
+    private static RabbitMQConnectionFactory Build(RabbitMQClientConfiguration configuration, CancellationTokenSource cts) =>
+        new(configuration, cts);
 
     private static void SetCachedConnection(RabbitMQConnectionFactory sut, IConnection? connection) =>
         ConnectionField.SetValue(sut, connection);
@@ -116,7 +119,8 @@ public class RabbitMQConnectionFactoryTests
     [Fact]
     public void GetConnectionFactory_EnablesAutomaticRecovery_ByDefault()
     {
-        var sut = Build(PlainSample());
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample(), cts);
 
         var factory = sut.GetConnectionFactory();
 
@@ -127,7 +131,8 @@ public class RabbitMQConnectionFactoryTests
     [Fact]
     public void GetConnectionFactory_AppliesCredentials_WhenMinimalConfig()
     {
-        var sut = Build(PlainSample());
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample(), cts);
 
         var factory = sut.GetConnectionFactory();
 
@@ -145,7 +150,8 @@ public class RabbitMQConnectionFactoryTests
     {
         var configuration = PlainSample();
         configuration.ClientProvidedName = "audit-sink";
-        var sut = Build(configuration);
+        using var cts = new CancellationTokenSource();
+        var sut = Build(configuration, cts);
 
         sut.GetConnectionFactory().ClientProvidedName.ShouldBe("audit-sink");
     }
@@ -155,7 +161,8 @@ public class RabbitMQConnectionFactoryTests
     {
         var configuration = PlainSample();
         configuration.Heartbeat = 45000;
-        var sut = Build(configuration);
+        using var cts = new CancellationTokenSource();
+        var sut = Build(configuration, cts);
 
         sut.GetConnectionFactory().RequestedHeartbeat.ShouldBe(TimeSpan.FromMilliseconds(45000));
     }
@@ -165,7 +172,8 @@ public class RabbitMQConnectionFactoryTests
     {
         var configuration = PlainSample();
         configuration.VHost = "/tenant-a";
-        var sut = Build(configuration);
+        using var cts = new CancellationTokenSource();
+        var sut = Build(configuration, cts);
 
         sut.GetConnectionFactory().VirtualHost.ShouldBe("/tenant-a");
     }
@@ -175,7 +183,8 @@ public class RabbitMQConnectionFactoryTests
     {
         var configuration = PlainSample();
         configuration.Port = 5673;
-        var sut = Build(configuration);
+        using var cts = new CancellationTokenSource();
+        var sut = Build(configuration, cts);
 
         sut.GetConnectionFactory().Port.ShouldBe(5673);
     }
@@ -183,7 +192,8 @@ public class RabbitMQConnectionFactoryTests
     [Fact]
     public void GetConnectionFactory_SetsHostName_ForSingleHostname()
     {
-        var sut = Build(PlainSample("rabbit-a.example.com"));
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample("rabbit-a.example.com"), cts);
 
         sut.GetConnectionFactory().HostName.ShouldBe("rabbit-a.example.com");
     }
@@ -194,7 +204,8 @@ public class RabbitMQConnectionFactoryTests
         // Multi-host cluster: HostName is not populated — the endpoint list drives the
         // connection attempts. Asserting the default (localhost) proves the branch that
         // sets it for the single-host case did not fire.
-        var sut = Build(PlainSample("rabbit-a.example.com", "rabbit-b.example.com"));
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample("rabbit-a.example.com", "rabbit-b.example.com"), cts);
 
         sut.GetConnectionFactory().HostName.ShouldBe("localhost");
     }
@@ -205,7 +216,8 @@ public class RabbitMQConnectionFactoryTests
         var configuration = SslSample("rabbit-a.example.com");
         configuration.SslOption!.Version = SslProtocols.Tls12;
         configuration.SslOption.AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateNameMismatch;
-        var sut = Build(configuration);
+        using var cts = new CancellationTokenSource();
+        var sut = Build(configuration, cts);
 
         var factory = sut.GetConnectionFactory();
 
@@ -219,7 +231,8 @@ public class RabbitMQConnectionFactoryTests
     {
         var configuration = SslSample("rabbit-a.example.com");
         configuration.SslOption!.CertPath = "/etc/ssl/client.pem";
-        var sut = Build(configuration);
+        using var cts = new CancellationTokenSource();
+        var sut = Build(configuration, cts);
 
         var mechanism = sut.GetConnectionFactory().AuthMechanisms.ShouldHaveSingleItem();
         mechanism.ShouldBeOfType<ExternalMechanismFactory>();
@@ -229,7 +242,8 @@ public class RabbitMQConnectionFactoryTests
     public void GetConnectionFactory_UsesDefaultAuthMechanisms_WhenSslHasNoCertPath()
     {
         var configuration = SslSample("rabbit-a.example.com");
-        var sut = Build(configuration);
+        using var cts = new CancellationTokenSource();
+        var sut = Build(configuration, cts);
 
         // No ExternalMechanismFactory override — the client-library default chain applies.
         sut.GetConnectionFactory().AuthMechanisms.ShouldNotContain(m => m is ExternalMechanismFactory);
@@ -241,7 +255,8 @@ public class RabbitMQConnectionFactoryTests
         // Fast-path: when _connection is already set, GetConnectionAsync short-circuits
         // before taking the semaphore. Covers the pre-lock return in GetConnectionAsync
         // without requiring a live broker.
-        var sut = Build(PlainSample());
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample(), cts);
         var cached = Substitute.For<IConnection>();
         SetCachedConnection(sut, cached);
 
@@ -259,7 +274,8 @@ public class RabbitMQConnectionFactoryTests
         // code is tracked separately as an open bug (#284 was auto-closed without a
         // fix). Pinning the current semaphore behaviour here would make the fix harder
         // to land.
-        var sut = Build(PlainSample());
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample(), cts);
         var connection = Substitute.For<IConnection>();
         SetCachedConnection(sut, connection);
 
@@ -271,7 +287,8 @@ public class RabbitMQConnectionFactoryTests
     [Fact]
     public async Task CloseAsync_DoesNotThrow_WhenNoConnectionCached()
     {
-        var sut = Build(PlainSample());
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample(), cts);
 
         await Should.NotThrowAsync(() => sut.CloseAsync());
     }
@@ -279,7 +296,8 @@ public class RabbitMQConnectionFactoryTests
     [Fact]
     public async Task DisposeAsync_ClosesAndDisposesConnection_WhenCached()
     {
-        var sut = Build(PlainSample());
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample(), cts);
         var connection = Substitute.For<IConnection>();
         SetCachedConnection(sut, connection);
 
@@ -292,7 +310,8 @@ public class RabbitMQConnectionFactoryTests
     [Fact]
     public async Task DisposeAsync_Noop_WhenNoConnection()
     {
-        var sut = Build(PlainSample());
+        using var cts = new CancellationTokenSource();
+        var sut = Build(PlainSample(), cts);
 
         await Should.NotThrowAsync(() => sut.DisposeAsync().AsTask());
     }
@@ -305,7 +324,9 @@ public class RabbitMQConnectionFactoryTests
         // the swallowed exception to SelfLog.
         using var selfLog = new SelfLogScope(out var selfLogBuilder);
 
-        var sut = Build(PlainSample());
+        using var cts = new CancellationTokenSource();
+
+        var sut = Build(PlainSample(), cts);
         var connection = Substitute.For<IConnection>();
         connection.When(c => c.CloseAsync(Arg.Any<CancellationToken>()))
             .Do(_ => throw new InvalidOperationException("close-boom"));

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQConnectionFactoryTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQConnectionFactoryTests.cs
@@ -1,7 +1,17 @@
+using System.Net.Security;
+using System.Reflection;
+using System.Security.Authentication;
+using Serilog.Sinks.RabbitMQ.Tests.TestHelpers;
+
 namespace Serilog.Sinks.RabbitMQ.Tests;
 
+[Collection("SelfLog")]
 public class RabbitMQConnectionFactoryTests
 {
+    private static readonly FieldInfo ConnectionField =
+        typeof(RabbitMQConnectionFactory).GetField("_connection", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("RabbitMQConnectionFactory._connection field not found.");
+
     private static RabbitMQClientConfiguration SslSample(params string[] hostnames) => new()
     {
         Hostnames = hostnames.ToList(),
@@ -9,6 +19,19 @@ public class RabbitMQConnectionFactoryTests
         Password = "guest",
         SslOption = new SslOption { Enabled = true },
     };
+
+    private static RabbitMQClientConfiguration PlainSample(params string[] hostnames) => new()
+    {
+        Hostnames = hostnames.Length == 0 ? ["localhost"] : hostnames.ToList(),
+        Username = "guest",
+        Password = "guest",
+    };
+
+    private static RabbitMQConnectionFactory Build(RabbitMQClientConfiguration configuration) =>
+        new(configuration, new CancellationTokenSource());
+
+    private static void SetCachedConnection(RabbitMQConnectionFactory sut, IConnection? connection) =>
+        ConnectionField.SetValue(sut, connection);
 
     [Fact]
     public void GetAmqpTcpEndpoints_EachEndpointHasServerNameMatchingItsOwnHostname_WhenNotExplicitlySet()
@@ -88,5 +111,208 @@ public class RabbitMQConnectionFactoryTests
 
         endpoints[0].Ssl.ServerName.ShouldBe("cluster.example.com");
         endpoints[1].Ssl.ServerName.ShouldBe("cluster.example.com");
+    }
+
+    [Fact]
+    public void GetConnectionFactory_EnablesAutomaticRecovery_ByDefault()
+    {
+        var sut = Build(PlainSample());
+
+        var factory = sut.GetConnectionFactory();
+
+        factory.AutomaticRecoveryEnabled.ShouldBeTrue();
+        factory.NetworkRecoveryInterval.ShouldBe(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void GetConnectionFactory_AppliesCredentials_WhenMinimalConfig()
+    {
+        var sut = Build(PlainSample());
+
+        var factory = sut.GetConnectionFactory();
+
+        factory.UserName.ShouldBe("guest");
+        factory.Password.ShouldBe("guest");
+
+        // RabbitMQ.Client uses -1 as the "unset" sentinel for Port and resolves it to
+        // the protocol-default (5672) at connect time. Asserting -1 here proves the
+        // `Port > 0` branch in GetConnectionFactory did not fire for the minimal config.
+        factory.Port.ShouldBe(-1);
+    }
+
+    [Fact]
+    public void GetConnectionFactory_SetsClientProvidedName_WhenConfigured()
+    {
+        var configuration = PlainSample();
+        configuration.ClientProvidedName = "audit-sink";
+        var sut = Build(configuration);
+
+        sut.GetConnectionFactory().ClientProvidedName.ShouldBe("audit-sink");
+    }
+
+    [Fact]
+    public void GetConnectionFactory_SetsRequestedHeartbeat_WhenPositive()
+    {
+        var configuration = PlainSample();
+        configuration.Heartbeat = 45000;
+        var sut = Build(configuration);
+
+        sut.GetConnectionFactory().RequestedHeartbeat.ShouldBe(TimeSpan.FromMilliseconds(45000));
+    }
+
+    [Fact]
+    public void GetConnectionFactory_SetsVirtualHost_WhenProvided()
+    {
+        var configuration = PlainSample();
+        configuration.VHost = "/tenant-a";
+        var sut = Build(configuration);
+
+        sut.GetConnectionFactory().VirtualHost.ShouldBe("/tenant-a");
+    }
+
+    [Fact]
+    public void GetConnectionFactory_AppliesPort_WhenPositive()
+    {
+        var configuration = PlainSample();
+        configuration.Port = 5673;
+        var sut = Build(configuration);
+
+        sut.GetConnectionFactory().Port.ShouldBe(5673);
+    }
+
+    [Fact]
+    public void GetConnectionFactory_SetsHostName_ForSingleHostname()
+    {
+        var sut = Build(PlainSample("rabbit-a.example.com"));
+
+        sut.GetConnectionFactory().HostName.ShouldBe("rabbit-a.example.com");
+    }
+
+    [Fact]
+    public void GetConnectionFactory_LeavesHostNameUnset_ForMultipleHostnames()
+    {
+        // Multi-host cluster: HostName is not populated — the endpoint list drives the
+        // connection attempts. Asserting the default (localhost) proves the branch that
+        // sets it for the single-host case did not fire.
+        var sut = Build(PlainSample("rabbit-a.example.com", "rabbit-b.example.com"));
+
+        sut.GetConnectionFactory().HostName.ShouldBe("localhost");
+    }
+
+    [Fact]
+    public void GetConnectionFactory_WiresSslOption_WhenConfigured()
+    {
+        var configuration = SslSample("rabbit-a.example.com");
+        configuration.SslOption!.Version = SslProtocols.Tls12;
+        configuration.SslOption.AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateNameMismatch;
+        var sut = Build(configuration);
+
+        var factory = sut.GetConnectionFactory();
+
+        factory.Ssl.Enabled.ShouldBeTrue();
+        factory.Ssl.Version.ShouldBe(SslProtocols.Tls12);
+        factory.Ssl.AcceptablePolicyErrors.ShouldBe(SslPolicyErrors.RemoteCertificateNameMismatch);
+    }
+
+    [Fact]
+    public void GetConnectionFactory_SelectsExternalMechanism_WhenSslCertPathProvided()
+    {
+        var configuration = SslSample("rabbit-a.example.com");
+        configuration.SslOption!.CertPath = "/etc/ssl/client.pem";
+        var sut = Build(configuration);
+
+        var mechanism = sut.GetConnectionFactory().AuthMechanisms.ShouldHaveSingleItem();
+        mechanism.ShouldBeOfType<ExternalMechanismFactory>();
+    }
+
+    [Fact]
+    public void GetConnectionFactory_UsesDefaultAuthMechanisms_WhenSslHasNoCertPath()
+    {
+        var configuration = SslSample("rabbit-a.example.com");
+        var sut = Build(configuration);
+
+        // No ExternalMechanismFactory override — the client-library default chain applies.
+        sut.GetConnectionFactory().AuthMechanisms.ShouldNotContain(m => m is ExternalMechanismFactory);
+    }
+
+    [Fact]
+    public async Task GetConnectionAsync_ReturnsCachedConnection_WhenAlreadyOpened()
+    {
+        // Fast-path: when _connection is already set, GetConnectionAsync short-circuits
+        // before taking the semaphore. Covers the pre-lock return in GetConnectionAsync
+        // without requiring a live broker.
+        var sut = Build(PlainSample());
+        var cached = Substitute.For<IConnection>();
+        SetCachedConnection(sut, cached);
+
+        var result = await sut.GetConnectionAsync();
+
+        result.ShouldBeSameAs(cached);
+    }
+
+    [Fact]
+    public async Task CloseAsync_CallsConnectionCloseAsync_WhenConnectionExists()
+    {
+        // Non-network-observable assertion: CloseAsync forwards to the cached
+        // IConnection.CloseAsync. Intentionally does NOT assert anything about the
+        // semaphore acquire/release pattern — the current 10 ms-timeout/never-released
+        // code is tracked separately as an open bug (#284 was auto-closed without a
+        // fix). Pinning the current semaphore behaviour here would make the fix harder
+        // to land.
+        var sut = Build(PlainSample());
+        var connection = Substitute.For<IConnection>();
+        SetCachedConnection(sut, connection);
+
+        await sut.CloseAsync();
+
+        await connection.Received(1).CloseAsync();
+    }
+
+    [Fact]
+    public async Task CloseAsync_DoesNotThrow_WhenNoConnectionCached()
+    {
+        var sut = Build(PlainSample());
+
+        await Should.NotThrowAsync(() => sut.CloseAsync());
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ClosesAndDisposesConnection_WhenCached()
+    {
+        var sut = Build(PlainSample());
+        var connection = Substitute.For<IConnection>();
+        SetCachedConnection(sut, connection);
+
+        await sut.DisposeAsync();
+
+        await connection.Received(1).CloseAsync();
+        connection.Received(1).Dispose();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_Noop_WhenNoConnection()
+    {
+        var sut = Build(PlainSample());
+
+        await Should.NotThrowAsync(() => sut.DisposeAsync().AsTask());
+    }
+
+    [Fact]
+    public async Task DisposeAsync_SwallowsConnectionException_AndLogsToSelfLog()
+    {
+        // Connection.CloseAsync throws on shutdown — DisposeAsync must not propagate,
+        // must still complete (disposing the semaphore in finally), and must report
+        // the swallowed exception to SelfLog.
+        using var selfLog = new SelfLogScope(out var selfLogBuilder);
+
+        var sut = Build(PlainSample());
+        var connection = Substitute.For<IConnection>();
+        connection.When(c => c.CloseAsync(Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("close-boom"));
+        SetCachedConnection(sut, connection);
+
+        await Should.NotThrowAsync(() => sut.DisposeAsync().AsTask());
+
+        selfLogBuilder.ToString().ShouldContain("close-boom");
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/TestHelpers/SelfLogCollection.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/TestHelpers/SelfLogCollection.cs
@@ -1,0 +1,12 @@
+namespace Serilog.Sinks.RabbitMQ.Tests.TestHelpers;
+
+/// <summary>
+/// xUnit collection that serialises every test class touching <see cref="Serilog.Debugging.SelfLog"/>.
+/// SelfLog is a process-wide static; without serialisation, parallel test classes race for the
+/// enabled writer and content assertions become flaky (see issue #282). Every test class that
+/// opens a <see cref="SelfLogScope"/> must declare <c>[Collection("SelfLog")]</c>.
+/// </summary>
+[CollectionDefinition("SelfLog", DisableParallelization = true)]
+public sealed class SelfLogCollection
+{
+}

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/TestHelpers/SelfLogScope.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/TestHelpers/SelfLogScope.cs
@@ -1,0 +1,34 @@
+using Serilog.Debugging;
+
+namespace Serilog.Sinks.RabbitMQ.Tests.TestHelpers;
+
+/// <summary>
+/// Scoped capture of <see cref="SelfLog"/> output for a single test. Enables SelfLog on
+/// construction against a fresh <see cref="StringWriter"/> and disables + disposes on
+/// <see cref="Dispose"/>. Replaces the manual <c>SelfLog.Enable(new StringWriter(sb))</c>
+/// pattern that leaked writers across tests and made content assertions race-prone.
+/// Any test class that uses this helper must carry <c>[Collection("SelfLog")]</c> so the
+/// shared global writer is not claimed by a parallel test class.
+/// </summary>
+internal sealed class SelfLogScope : IDisposable
+{
+    private readonly StringWriter _writer;
+    private bool _disposed;
+
+    public SelfLogScope(out StringBuilder output)
+    {
+        output = new StringBuilder();
+        _writer = new StringWriter(output);
+        SelfLog.Enable(_writer);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        SelfLog.Disable();
+        _writer.Dispose();
+        _disposed = true;
+    }
+}


### PR DESCRIPTION
Closes #285, closes #282.

Pure test project changes plus one `private -> internal` adjustment in `RabbitMQConnectionFactory` to match the existing `GetAmqpTcpEndpoints` testing precedent. No public API change, no behaviour change.

## #285 — coverage for LoggerConfigurationRabbitMQExtensions and RabbitMQConnectionFactory

Before this PR, the flat-parameter overloads and most of the connection-factory wiring helpers were exercised **only** by the integration suite (docker broker required). Coverage on the two target classes:

| | Before | After |
|---|---|---|
| Total line  | 73.95% | 99.40% |
| Total branch | 61.84% | 98.68% |

### `LoggerConfigurationRabbitMQExtensions`

- `WriteTo.RabbitMQ` / `AuditTo.RabbitMQ` flat overloads — one test with defaults, one with every option set, one for `sslEnabled` without `sslServerName` (the SslOption-not-built edge case), and one with `batchPostingLimit: 0` to hit the default-substitution branch.
- Delegate overloads (sink + audit) — confirm the configure delegate fires.
- `failureSinkConfiguration` wrapper path; `QueueLimit` forwarding in `GetPeriodicBatchingSink`.
- `RegisterSink` default-substitution for `BatchPostingLimit` / `BufferingTimeLimit` when they arrive at their CLR defaults.

**Scope note — flat-overload tests are coverage-only, not behavioural.** The "AllOptions", "Defaults", and `SslEnabledWithoutServerName` tests assert only `logger.ShouldNotBeNull()`. They execute every branch in the flat overload for coverage, but do NOT verify that a given parameter (e.g. `channelCount: 2`, `sslVersion: Tls12`) was actually applied to the resulting sink. Verifying that would require either wider `internal` exposure or reflection-based introspection of the constructed sink, both of which felt out of scope for a test-hygiene PR. The exception is `AppliesDefaults_WhenBatchingValuesAreDefault`, which asserts the caller's `sinkConfig` object was mutated to the library defaults — the one behavioural check.

### `RabbitMQConnectionFactory`

- Made `GetConnectionFactory()` `internal` (same precedent as `GetAmqpTcpEndpoints`). Tests now cover: auto-recovery defaults, credentials + unset-port sentinel (-1), `ClientProvidedName`, `RequestedHeartbeat`, `VirtualHost`, explicit `Port`, single- vs multi-hostname `HostName` branch, `SslOption` wiring, and `ExternalMechanismFactory` selection when `SslOption.CertPath` is set.
- `GetConnectionAsync` cached-connection fast path via reflection-set `_connection` (slow path requires a live broker — scoped out by the issue).
- `CloseAsync` / `DisposeAsync` happy path, no-connection no-op, and SelfLog-on-exception path.

The only remaining gap on the target classes is the `GetConnectionAsync` slow path at line 60/66 that calls `ConnectionFactory.CreateConnectionAsync(...)` — requires a live broker, covered by integration tests.

## #282 — SelfLog test hygiene

`Serilog.Debugging.SelfLog` is a process-wide static. xUnit runs classes in parallel by default, so classes that call `SelfLog.Enable(writer)` raced for the global writer slot — this forced removal of content assertions (commits `49fb766` dispose-boom, `43a933f` deadlock-test SelfLog-empty).

- **`TestHelpers/SelfLogScope`** — scoped `IDisposable` that enables/disables SelfLog against a fresh `StringWriter` and disposes it deterministically. Replaces the manual `SelfLog.Enable(new StringWriter(sb))` pattern and fixes the `StringWriter` leaks at the prior RabbitMQSinkTests.cs lines 265 and 294.
- **`TestHelpers/SelfLogCollection`** — `[CollectionDefinition("SelfLog", DisableParallelization = true)]`. Every class that either enables SelfLog directly or spawns background tasks that write to SelfLog (real-sink warmup) now carries `[Collection("SelfLog")]`:
  - `RabbitMQSinkTests`
  - `RabbitMQChannelPoolTests`
  - `RabbitMQConnectionFactoryTests` (via the dispose-exception test)
  - `LoggerConfigurationRabbitMQExtensionsTests` (its flat-overload tests construct real sinks whose background warmup emits SelfLog output — without the attribute those writes race with sibling `ShouldBeEmpty`/`ShouldContain` assertions, reopening the exact flake class #282 targets)
- **Restored the two content assertions that had to be dropped**:
  - `selfLogBuilder.ShouldContain("dispose-boom")` in `ReturnAsync_WhenBrokenChannelDisposeThrows_StillRefillsPoolAndLogs`.
  - `selfLogBuilder.ShouldBeEmpty()` in `Dispose_ShouldNotDeadlock_WhenCalledOnSingleThreadedSynchronizationContext`.

## Note on issue #284 (out of scope)

Issue #284 is marked CLOSED on GitHub but the bug it describes (`CloseAsync`'s `WaitAsync(10)` timeout never released) is still in master — `Fixes #284` in PR #287 auto-closed it without actually fixing anything. The new `CloseAsync` tests in this PR intentionally do **not** assert the semaphore acquire/release pattern so they stay green after that bug is fixed. Recommend reopening #284.

## Test plan

- [x] `dotnet build -c Release --no-restore` — 0 warnings / 0 errors across `netstandard2.0`, `net8.0`, `net10.0` (+ `net48` for tests).
- [x] Unit tests on `net10.0` — 114 passed (was 85; +29 new, +1 theory case).
- [x] Unit tests on `net8.0` — 113 passed (was 84).
- [x] `dotnet format --no-restore --verify-no-changes --severity warn` — clean.
- [x] Coverage — target classes at 99.4% line / 98.68% branch; the only remaining gap is `GetConnectionAsync` slow path that requires a live broker (scoped out by #285).
- [x] Public API approval snapshot — unchanged.
- [ ] Windows CI validates net48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)