### PR TITLE
Bounded warm-up retry with backoff + circuit-breaker self-heal (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,7 +266,7 @@ The warm-up path now:
   failure listener / `Fallback` chain. The separate 60 s cooldown window (after the
   breaker has tripped, before the next probe) is handled by the fail-fast path above.
 
-Set `WarmUpMaxRetries = 0` to preserve the pre-9.0 behaviour of retrying indefinitely. The
+Set `WarmUpMaxRetries = null` to preserve the pre-9.0 behaviour of retrying indefinitely. The
 backoff schedule itself is not configurable.
 
 ### Renamed `MaxChannels` to `ChannelCount`
@@ -296,4 +296,4 @@ renamed to `channelCount`. Update appsettings JSON / `App.config` keys from `max
   legacy catch-and-route behaviour.
 - Warm-up now stops after `WarmUpMaxRetries` consecutive failures (default `10`) and a
   broken pool fails `GetAsync` fast instead of blocking waiters. Set
-  `WarmUpMaxRetries = 0` to opt back into unlimited retries.
+  `WarmUpMaxRetries = null` to opt back into unlimited retries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,12 +256,15 @@ The warm-up path now:
   the pool re-enters `Broken` with a fresh 60 s cooldown. Concurrent `GetAsync` callers
   during the probe see exhaustion — only one probe runs at a time.
 - **Wakes in-flight waiters on exhaustion**: a `GetAsync` call that parked on the empty
-  channel during the 62 s backoff window (typical for a broker-down scenario starting
-  with no channels in the pool) now wakes as soon as the breaker trips, instead of
-  staying hung for the rest of the outage. Without this, `BatchingSink`'s flush loop
-  would sit behind the hung `EmitBatchAsync` and the in-memory event queue would grow
-  indefinitely. With it, the hung call surfaces the exhaustion exception and
-  subsequent batches drain through the failure listener / `Fallback` chain.
+  channel during the cumulative warm-up backoff (the time spent in the retry loop before
+  the breaker trips — roughly ~2 minutes with the default `WarmUpMaxRetries = 10` and
+  the backoff schedule above, and shorter/longer when `WarmUpMaxRetries` is tuned) now
+  wakes as soon as the breaker trips, instead of staying hung for the rest of the
+  outage. Without this, `BatchingSink`'s flush loop would sit behind the hung
+  `EmitBatchAsync` and the in-memory event queue would grow indefinitely. With it, the
+  hung call surfaces the exhaustion exception and subsequent batches drain through the
+  failure listener / `Fallback` chain. The separate 60 s cooldown window (after the
+  breaker has tripped, before the next probe) is handled by the fail-fast path above.
 
 Set `WarmUpMaxRetries = 0` to preserve the pre-9.0 behaviour of retrying indefinitely. The
 backoff schedule itself is not configurable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,35 @@ checks:
   `QueueLimit` previously passed through to Serilog's batching layer silently;
   it is now rejected at configuration time.
 
+### Bounded warm-up retry with exponential backoff and circuit-breaker self-heal
+
+`RabbitMQChannelPool` used to retry warm-up forever on a fixed 500 ms interval. Under a
+sustained broker outage that meant constant wake-ups, `SelfLog` flooded with "Failed to
+warm up RabbitMQ channel" entries, and callers blocked on `GetAsync` indefinitely because
+the pool never filled.
+
+The warm-up path now:
+
+- **Backs off exponentially**: 500 ms → 1 s → 2 s → 4 s → 8 s → 16 s → 30 s (cap). The
+  failure counter resets on any successful channel creation, so a single transient blip
+  cannot combine with later failures to reach the cap.
+- **Gives up after `RabbitMQClientConfiguration.WarmUpMaxRetries` consecutive failures**
+  (default **10**). On exhaustion the pool transitions to a `Broken` state.
+- **Fails fast from `GetAsync`** while broken — throws
+  `InvalidOperationException("Channel pool exhausted after N consecutive warm-up failures; broker is unreachable.")`.
+  That propagates through `RabbitMQClient.PublishAsync` → `RabbitMQSink.EmitBatchAsync` →
+  Serilog's `BatchingSink`, which invokes its failure listener. If you wrap the sink with
+  `WriteTo.Fallback(primary: s => s.RabbitMQ(...), fallback: s => s.File(...))`, failed
+  events automatically route to the fallback instead of piling up in the batching queue.
+- **Self-heals after a 60 s cooldown**: the first `GetAsync` after the cooldown elapses
+  claims a probe slot via CAS, attempts one warm-up, and on success transitions the pool
+  back to `Warming` (with a background refill of the remaining channels). On probe failure
+  the pool re-enters `Broken` with a fresh 60 s cooldown. Concurrent `GetAsync` callers
+  during the probe see exhaustion — only one probe runs at a time.
+
+Set `WarmUpMaxRetries = 0` to preserve the pre-9.0 behaviour of retrying indefinitely. The
+backoff schedule itself is not configurable.
+
 ### Renamed `MaxChannels` to `ChannelCount`
 
 `RabbitMQClientConfiguration.MaxChannels` has been renamed to `ChannelCount` to reflect that
@@ -255,3 +284,6 @@ renamed to `channelCount`. Update appsettings JSON / `App.config` keys from `max
 - `RabbitMQSink.EmitBatchAsync` propagates publish exceptions by default instead of
   silently swallowing them. Use `EmitEventFailureHandling.WriteToFailureSink` to keep
   legacy catch-and-route behaviour.
+- Warm-up now stops after `WarmUpMaxRetries` consecutive failures (default `10`) and a
+  broken pool fails `GetAsync` fast instead of blocking waiters. Set
+  `WarmUpMaxRetries = 0` to opt back into unlimited retries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,13 @@ The warm-up path now:
   back to `Warming` (with a background refill of the remaining channels). On probe failure
   the pool re-enters `Broken` with a fresh 60 s cooldown. Concurrent `GetAsync` callers
   during the probe see exhaustion — only one probe runs at a time.
+- **Wakes in-flight waiters on exhaustion**: a `GetAsync` call that parked on the empty
+  channel during the 62 s backoff window (typical for a broker-down scenario starting
+  with no channels in the pool) now wakes as soon as the breaker trips, instead of
+  staying hung for the rest of the outage. Without this, `BatchingSink`'s flush loop
+  would sit behind the hung `EmitBatchAsync` and the in-memory event queue would grow
+  indefinitely. With it, the hung call surfaces the exhaustion exception and
+  subsequent batches drain through the failure listener / `Fallback` chain.
 
 Set `WarmUpMaxRetries = 0` to preserve the pre-9.0 behaviour of retrying indefinitely. The
 backoff schedule itself is not configurable.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Keys are case-insensitive.
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `channelCount` | `int` | `64` | Number of channels held in the pool. Channels are opened eagerly in the background at startup; broken channels are replaced automatically. When all channels are in use, additional publish calls await until one is returned. |
-| `warmUpMaxRetries` | `int` | `10` | Maximum consecutive warm-up failures before the pool enters a broken state. While broken, `GetAsync` throws `InvalidOperationException` immediately so publish failures surface to the `BatchingSink` failure listener (or `WriteTo.Fallback(...)` chain) instead of blocking waiters. A 60 s cooldown elapses between exhaustion and the next probe attempt; probe success transitions the pool back to warming. Set to `0` for unlimited retries (pre-9.0 behaviour). The exponential backoff schedule between attempts (500 ms → 30 s cap) is not configurable. |
+| `warmUpMaxRetries` | `int?` | `10` | Maximum consecutive warm-up failures before the pool enters a broken state. While broken, `GetAsync` throws `InvalidOperationException` immediately so publish failures surface to the `BatchingSink` failure listener (or `WriteTo.Fallback(...)` chain) instead of blocking waiters. A 60 s cooldown elapses between exhaustion and the next probe attempt; probe success transitions the pool back to warming. Set to `null` for unlimited retries (pre-9.0 behaviour). The exponential backoff schedule between attempts (500 ms → 30 s cap) is not configurable. |
 
 > **Deprecated:** `maxChannels` (parameter) and `MaxChannels` (property) are kept as
 > `[Obsolete]` shims that forward to `channelCount` / `ChannelCount`. They will be removed in
@@ -429,7 +429,7 @@ and integration tests.
   failures (default `10`). A broken pool fails `GetAsync` fast so events surface to Serilog's
   `BatchingSink` failure listener (or `WriteTo.Fallback(...)`) instead of blocking waiters.
   Self-heals via a half-open probe after a 60 s cooldown. Set
-  `RabbitMQClientConfiguration.WarmUpMaxRetries = 0` for unlimited retries — matches pre-9.0
+  `RabbitMQClientConfiguration.WarmUpMaxRetries = null` for unlimited retries — matches pre-9.0
   behaviour, but prefer `WriteTo.Fallback(...)` for resilience instead.
 - **`Microsoft.Extensions.ObjectPool` dependency removed.** No action needed unless your
   application referenced it transitively through this package.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Keys are case-insensitive.
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `channelCount` | `int` | `64` | Number of channels held in the pool. Channels are opened eagerly in the background at startup; broken channels are replaced automatically. When all channels are in use, additional publish calls await until one is returned. |
+| `warmUpMaxRetries` | `int` | `10` | Maximum consecutive warm-up failures before the pool enters a broken state. While broken, `GetAsync` throws `InvalidOperationException` immediately so publish failures surface to the `BatchingSink` failure listener (or `WriteTo.Fallback(...)` chain) instead of blocking waiters. A 60 s cooldown elapses between exhaustion and the next probe attempt; probe success transitions the pool back to warming. Set to `0` for unlimited retries (pre-9.0 behaviour). The exponential backoff schedule between attempts (500 ms → 30 s cap) is not configurable. |
 
 > **Deprecated:** `maxChannels` (parameter) and `MaxChannels` (property) are kept as
 > `[Obsolete]` shims that forward to `channelCount` / `ChannelCount`. They will be removed in
@@ -423,6 +424,13 @@ and integration tests.
   or a negative value now throws `ArgumentOutOfRangeException` at configuration time;
   previously the channel pool silently substituted the default of 64. Omit the property (or
   leave the parameter at its default) to keep the default pool size.
+- **Bounded warm-up retry with circuit-breaker recovery.** `RabbitMQChannelPool` now backs
+  off exponentially (500 ms → 30 s cap) and gives up after `WarmUpMaxRetries` consecutive
+  failures (default `10`). A broken pool fails `GetAsync` fast so events surface to Serilog's
+  `BatchingSink` failure listener (or `WriteTo.Fallback(...)`) instead of blocking waiters.
+  Self-heals via a half-open probe after a 60 s cooldown. Set
+  `RabbitMQClientConfiguration.WarmUpMaxRetries = 0` for unlimited retries — matches pre-9.0
+  behaviour, but prefer `WriteTo.Fallback(...)` for resilience instead.
 - **`Microsoft.Extensions.ObjectPool` dependency removed.** No action needed unless your
   application referenced it transitively through this package.
 - **Target frameworks:** `net6.0` and `net9.0` were removed. Supported targets are

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
 using RabbitMQ.Client;
@@ -26,15 +27,52 @@ namespace Serilog.Sinks.RabbitMQ;
 /// </summary>
 internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
 {
-    private static readonly TimeSpan WARM_UP_RETRY_DELAY = TimeSpan.FromMilliseconds(500);
+    /// <summary>
+    /// Cooldown between exhaustion and the next probe attempt. Intentionally not
+    /// user-configurable — exposed as an internal constant so the circuit-breaker
+    /// tests can reason about wall-clock timing without touching private state.
+    /// </summary>
+    internal const int BROKEN_COOLDOWN_MS = 60_000;
+
+    /// <summary>
+    /// Cooldown expressed in <see cref="Stopwatch"/> ticks. <c>Stopwatch</c> is portable
+    /// across every target framework (unlike <c>Environment.TickCount64</c>, which is
+    /// .NET 5+) and is monotonic — wall-clock adjustments do not retroactively shrink or
+    /// extend an in-flight cooldown.
+    /// </summary>
+    private static readonly long BROKEN_COOLDOWN_STOPWATCH_TICKS =
+        Stopwatch.Frequency * BROKEN_COOLDOWN_MS / 1000;
+
+    /// <summary>
+    /// Lifecycle states for the channel pool. Exposed internally so the circuit-breaker
+    /// tests can observe the state machine without reflecting on the backing int field.
+    /// </summary>
+    internal enum PoolState
+    {
+        /// <summary>Initial state: warm-up is filling the pool for the first time.</summary>
+        Warming = 0,
+
+        /// <summary>Fully warmed — all channels are in the pool (or checked out).</summary>
+        Open = 1,
+
+        /// <summary>Exhausted retries; <c>GetAsync</c> throws until the cooldown elapses.</summary>
+        Broken = 2,
+
+        /// <summary>Cooldown expired; a single probe warm-up is in flight.</summary>
+        Probing = 3,
+    }
 
     private readonly RabbitMQClientConfiguration _config;
     private readonly IRabbitMQConnectionFactory _connectionFactory;
     private readonly int _size;
+    private readonly int _maxRetries;
     private readonly Channel<IRabbitMQChannel> _channels;
     private readonly SemaphoreSlim _exchangeDeclareLock = new(1, 1);
     private readonly CancellationTokenSource _shutdownCts = new();
     private volatile bool _exchangeDeclared;
+    private int _state; // PoolState as int for Interlocked APIs
+    private long _brokenUntilTicks; // Environment.TickCount64 at which the cooldown expires
+    private int _consecutiveFailures;
     private int _disposed;
 
     /// <summary>
@@ -50,14 +88,29 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
         _config = configuration;
         _connectionFactory = connectionFactory;
         _size = configuration.ChannelCount;
+        _maxRetries = configuration.WarmUpMaxRetries;
         _channels = Channel.CreateBounded<IRabbitMQChannel>(_size);
+        _state = (int)PoolState.Warming;
 
-        _ = Task.Run(() => WarmUpAsync(_size, _shutdownCts.Token));
+        _ = Task.Run(() => WarmUpAsync(_size, markOpenOnCompletion: true, _shutdownCts.Token));
     }
+
+    /// <summary>
+    /// Current lifecycle state. Exposed for circuit-breaker tests so they can
+    /// synchronise on state transitions without reflecting on the backing field.
+    /// </summary>
+    internal PoolState CurrentState => (PoolState)Volatile.Read(ref _state);
 
     /// <inheritdoc />
     public async ValueTask<IRabbitMQChannel> GetAsync(CancellationToken cancellationToken = default)
     {
+        var state = (PoolState)Volatile.Read(ref _state);
+
+        if (state == PoolState.Broken || state == PoolState.Probing)
+        {
+            await HandleBrokenStateAsync(state, cancellationToken).ConfigureAwait(false);
+        }
+
         try
         {
             return await _channels.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
@@ -76,6 +129,78 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             throw new InvalidOperationException("Channel pool has been disposed.");
         }
     }
+
+    /// <summary>
+    /// Called from <see cref="GetAsync"/> when the pool state is <see cref="PoolState.Broken"/>
+    /// or <see cref="PoolState.Probing"/>. Either throws the exhaustion exception (cooldown
+    /// not elapsed, or another caller already owns the probe), or transitions to
+    /// <see cref="PoolState.Probing"/>, runs a single warm-up attempt, and — on success —
+    /// transitions to <see cref="PoolState.Warming"/> and kicks off full refill before
+    /// returning so the caller can await <c>ReadAsync</c>.
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Probe is a single-shot warm-up whose outcome determines whether the circuit-breaker stays open; any exception other than caller-cancellation must route the pool back to Broken without leaking. Original failure is summarised via SelfLog.")]
+    private async Task HandleBrokenStateAsync(PoolState observedState, CancellationToken cancellationToken)
+    {
+        if (observedState == PoolState.Probing)
+        {
+            throw PoolExhaustedException();
+        }
+
+        var now = Stopwatch.GetTimestamp();
+        var brokenUntil = Volatile.Read(ref _brokenUntilTicks);
+        if (now < brokenUntil)
+        {
+            throw PoolExhaustedException();
+        }
+
+        // Cooldown elapsed. Try to claim the probe role; only one caller wins the CAS.
+        if (Interlocked.CompareExchange(ref _state, (int)PoolState.Probing, (int)PoolState.Broken) != (int)PoolState.Broken)
+        {
+            throw PoolExhaustedException();
+        }
+
+        try
+        {
+            var channel = await CreateChannelAsync(cancellationToken).ConfigureAwait(false);
+            if (!_channels.Writer.TryWrite(channel))
+            {
+                // Pool disposed mid-probe — dispose the orphan and fall through. The
+                // caller's ReadAsync then observes ChannelClosedException and surfaces
+                // the disposal consistently with the non-probe path.
+                await channel.DisposeAsync().ConfigureAwait(false);
+                return;
+            }
+
+            // Probe succeeded — reset counter, transition to Warming, kick off refill.
+            Volatile.Write(ref _consecutiveFailures, 0);
+            Interlocked.Exchange(ref _state, (int)PoolState.Warming);
+            _ = Task.Run(() => WarmUpAsync(_size, markOpenOnCompletion: true, _shutdownCts.Token));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller cancelled; restore Broken so the next caller can probe again.
+            RecordProbeFailure();
+            throw;
+        }
+        catch (Exception ex)
+        {
+            SelfLog.WriteLine("Probe warm-up failed; pool remains broken: {0}", ex);
+            RecordProbeFailure();
+            throw PoolExhaustedException();
+        }
+    }
+
+    private void RecordProbeFailure()
+    {
+        Volatile.Write(ref _brokenUntilTicks, Stopwatch.GetTimestamp() + BROKEN_COOLDOWN_STOPWATCH_TICKS);
+        Interlocked.Exchange(ref _state, (int)PoolState.Broken);
+    }
+
+    private InvalidOperationException PoolExhaustedException() =>
+        new($"Channel pool exhausted after {_maxRetries} consecutive warm-up failures; broker is unreachable.");
 
     /// <inheritdoc />
     public ValueTask ReturnAsync(IRabbitMQChannel channel)
@@ -110,7 +235,9 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                 SelfLog.WriteLine("Failed to dispose broken RabbitMQ channel during return: {0}", ex.Message);
             }
 
-            await WarmUpAsync(1, _shutdownCts.Token).ConfigureAwait(false);
+            // Refill is "opportunistic" — don't advance state to Open on completion. Only
+            // full initial warm-ups (and post-probe refills) do that.
+            await WarmUpAsync(1, markOpenOnCompletion: false, _shutdownCts.Token).ConfigureAwait(false);
         });
         return default;
     }
@@ -159,7 +286,7 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
         _shutdownCts.Dispose();
     }
 
-    private async Task WarmUpAsync(int count, CancellationToken cancellationToken)
+    private async Task WarmUpAsync(int count, bool markOpenOnCompletion, CancellationToken cancellationToken)
     {
         for (int i = 0; i < count; i++)
         {
@@ -168,20 +295,36 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                 return;
             }
         }
+
+        if (markOpenOnCompletion)
+        {
+            // Full warm-up completed. Only advance Warming → Open; callers in Broken or
+            // Probing may have transitioned us while this task was running (e.g. a refill
+            // warm-up raced the probe state machine) and those transitions must stand.
+            Interlocked.CompareExchange(ref _state, (int)PoolState.Open, (int)PoolState.Warming);
+        }
     }
 
     [SuppressMessage(
         "Design",
         "CA1031:Do not catch general exception types",
-        Justification = "Warm-up retries on any transient broker error so the pool can recover from network or broker hiccups without taking the sink down.")]
+        Justification = "Warm-up retries on any transient broker error so the pool can recover from network or broker hiccups without taking the sink down. Only exhaustion (and shutdown) terminates the loop.")]
     private async Task<bool> WarmUpSingleAsync(CancellationToken cancellationToken)
     {
         // while (true): all exits happen through return paths inside the body (success,
-        // orphan, or cancellation from one of the awaited operations). Looping with an
-        // explicit cancellation-check as the condition added an unreachable-in-practice
-        // branch that skewed coverage for no added safety.
+        // orphan, cancellation, or exhaustion). Looping with an explicit cancellation
+        // check as the condition added an unreachable-in-practice branch that skewed
+        // coverage for no added safety.
         while (true)
         {
+            // Don't attempt if another warm-up already transitioned us to Broken — let
+            // the circuit breaker's cooldown hold. (Broken state is reset on probe
+            // success by HandleBrokenStateAsync.)
+            if ((PoolState)Volatile.Read(ref _state) == PoolState.Broken)
+            {
+                return false;
+            }
+
             try
             {
                 var channel = await CreateChannelAsync(cancellationToken).ConfigureAwait(false);
@@ -192,6 +335,10 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                     return false;
                 }
 
+                // Any successful channel addition resets the consecutive-failure counter,
+                // so a single transient blip cannot combine with later failures to reach
+                // WarmUpMaxRetries.
+                Volatile.Write(ref _consecutiveFailures, 0);
                 return true;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -200,10 +347,26 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             }
             catch (Exception ex)
             {
-                SelfLog.WriteLine("Failed to warm up RabbitMQ channel: {0}", ex);
+                var failures = Interlocked.Increment(ref _consecutiveFailures);
+                SelfLog.WriteLine("Failed to warm up RabbitMQ channel (attempt {0}): {1}", failures, ex);
+
+                if (_maxRetries > 0 && failures >= _maxRetries)
+                {
+                    SelfLog.WriteLine(
+                        "Channel pool exhausted after {0} consecutive warm-up failures; breaking for {1} ms.",
+                        _maxRetries,
+                        BROKEN_COOLDOWN_MS);
+                    Volatile.Write(ref _brokenUntilTicks, Stopwatch.GetTimestamp() + BROKEN_COOLDOWN_STOPWATCH_TICKS);
+
+                    // Only transition from Warming/Open; the probing path owns its own transitions.
+                    _ = Interlocked.CompareExchange(ref _state, (int)PoolState.Broken, (int)PoolState.Warming);
+                    _ = Interlocked.CompareExchange(ref _state, (int)PoolState.Broken, (int)PoolState.Open);
+                    return false;
+                }
+
                 try
                 {
-                    await Task.Delay(WARM_UP_RETRY_DELAY, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(GetBackoffDelay(failures), cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -212,6 +375,22 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             }
         }
     }
+
+    /// <summary>
+    /// Exponential backoff schedule used between warm-up attempts. Input is the
+    /// consecutive-failure count *after* the failure that triggered the delay, so
+    /// attempt 1 → 500 ms, attempt 2 → 1 s, doubling up to a 30 s cap.
+    /// </summary>
+    internal static TimeSpan GetBackoffDelay(int failures) => failures switch
+    {
+        <= 1 => TimeSpan.FromMilliseconds(500),
+        2 => TimeSpan.FromSeconds(1),
+        3 => TimeSpan.FromSeconds(2),
+        4 => TimeSpan.FromSeconds(4),
+        5 => TimeSpan.FromSeconds(8),
+        6 => TimeSpan.FromSeconds(16),
+        _ => TimeSpan.FromSeconds(30),
+    };
 
     [SuppressMessage(
         "Design",

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -138,12 +138,13 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
 
         // Link the caller's token with the "pool became unhealthy" signal so a
         // state transition to Broken wakes up any in-flight ReadAsync waiter —
-        // otherwise a caller that parked during Warming (before the 62 s
-        // exhaustion tipped the breaker) stays hung on the empty channel until
-        // the probe eventually succeeds, blocking BatchingSink from processing
-        // new batches and letting the queue grow indefinitely. Waking the
-        // waiter lets it route through the catch below to the exhaustion
-        // exception, which in turn routes events to the configured fallback.
+        // otherwise a caller that parked during Warming (before the cumulative
+        // warm-up backoff, controlled by WarmUpMaxRetries + GetBackoffDelay,
+        // exhausts) stays hung on the empty channel until the probe eventually
+        // succeeds, blocking BatchingSink from processing new batches and letting
+        // the queue grow indefinitely. Waking the waiter lets it route through
+        // the catch below to the exhaustion exception, which in turn routes events
+        // to the configured fallback.
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _unhealthySignalCts.Token);
         try
         {

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -71,9 +71,18 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     private readonly CancellationTokenSource _shutdownCts = new();
     private volatile bool _exchangeDeclared;
     private int _state; // PoolState as int for Interlocked APIs
-    private long _brokenUntilTicks; // Environment.TickCount64 at which the cooldown expires
+    private long _brokenUntilTicks; // Stopwatch.GetTimestamp() at which the cooldown expires
     private int _consecutiveFailures;
     private int _disposed;
+
+    /// <summary>
+    /// Cancelled when the pool transitions to <see cref="PoolState.Broken"/> so any
+    /// <see cref="GetAsync"/> caller currently parked in <c>ReadAsync</c> wakes up and
+    /// routes to the batching sink's failure listener instead of staying hung for the
+    /// remainder of the outage. Replaced with a fresh instance on probe success so the
+    /// next pre-exhaustion window starts clean.
+    /// </summary>
+    private CancellationTokenSource _unhealthySignalCts = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RabbitMQChannelPool"/> class
@@ -101,9 +110,25 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     /// </summary>
     internal PoolState CurrentState => (PoolState)Volatile.Read(ref _state);
 
+    /// <summary>
+    /// Test-only setter for the state field. Used by the CAS-lost probe-race test to
+    /// force an atypical state/observedState divergence; not wired up in production.
+    /// </summary>
+    internal void TestingSetState(PoolState state) => Volatile.Write(ref _state, (int)state);
+
     /// <inheritdoc />
     public async ValueTask<IRabbitMQChannel> GetAsync(CancellationToken cancellationToken = default)
     {
+        // Fast path for a disposed pool: accessing _unhealthySignalCts.Token below
+        // would throw ObjectDisposedException after DisposeAsync ran, which is
+        // technically an InvalidOperationException but bypasses the structured
+        // ChannelClosedException / OCE mapping below. Short-circuit here so the
+        // disposal signal is deterministic.
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            throw new InvalidOperationException("Channel pool has been disposed.");
+        }
+
         var state = (PoolState)Volatile.Read(ref _state);
 
         if (state == PoolState.Broken || state == PoolState.Probing)
@@ -111,9 +136,18 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             await HandleBrokenStateAsync(state, cancellationToken).ConfigureAwait(false);
         }
 
+        // Link the caller's token with the "pool became unhealthy" signal so a
+        // state transition to Broken wakes up any in-flight ReadAsync waiter —
+        // otherwise a caller that parked during Warming (before the 62 s
+        // exhaustion tipped the breaker) stays hung on the empty channel until
+        // the probe eventually succeeds, blocking BatchingSink from processing
+        // new batches and letting the queue grow indefinitely. Waking the
+        // waiter lets it route through the catch below to the exhaustion
+        // exception, which in turn routes events to the configured fallback.
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _unhealthySignalCts.Token);
         try
         {
-            return await _channels.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            return await _channels.Reader.ReadAsync(linked.Token).ConfigureAwait(false);
         }
         catch (ChannelClosedException)
         {
@@ -127,6 +161,19 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             // OperationCanceledException whose token might belong to either party
             // (issue #286 item 2).
             throw new InvalidOperationException("Channel pool has been disposed.");
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Unhealthy-signal fired. Re-read state — if we've transitioned to Broken
+            // or Probing, surface the exhaustion exception so the batch rethrows and
+            // BatchingSink routes to the failure listener / Fallback chain.
+            var next = (PoolState)Volatile.Read(ref _state);
+            if (next == PoolState.Broken || next == PoolState.Probing)
+            {
+                throw PoolExhaustedException();
+            }
+
+            throw;
         }
     }
 
@@ -174,8 +221,11 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                 return;
             }
 
-            // Probe succeeded — reset counter, transition to Warming, kick off refill.
+            // Probe succeeded — reset counter, install a fresh unhealthy signal (the
+            // previous one fired on exhaustion and would instantly poison new waiters),
+            // transition to Warming, kick off refill.
             Volatile.Write(ref _consecutiveFailures, 0);
+            Interlocked.Exchange(ref _unhealthySignalCts, new CancellationTokenSource()).Dispose();
             Interlocked.Exchange(ref _state, (int)PoolState.Warming);
             _ = Task.Run(() => WarmUpAsync(_size, markOpenOnCompletion: true, _shutdownCts.Token));
         }
@@ -197,10 +247,42 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     {
         Volatile.Write(ref _brokenUntilTicks, Stopwatch.GetTimestamp() + BROKEN_COOLDOWN_STOPWATCH_TICKS);
         Interlocked.Exchange(ref _state, (int)PoolState.Broken);
+        SignalUnhealthy();
+    }
+
+    /// <summary>
+    /// Trips the unhealthy signal so any in-flight <see cref="GetAsync"/> waiter wakes
+    /// and observes the transition to <see cref="PoolState.Broken"/>. Idempotent —
+    /// subsequent calls on a cancelled CTS are no-ops.
+    /// </summary>
+    private void SignalUnhealthy()
+    {
+        try
+        {
+            _unhealthySignalCts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Racing with DisposeAsync; the signal no longer matters.
+        }
     }
 
     private InvalidOperationException PoolExhaustedException() =>
         new($"Channel pool exhausted after {_maxRetries} consecutive warm-up failures; broker is unreachable.");
+
+    /// <summary>
+    /// Test-only hook for the CAS-lost probe race. Production callers enter
+    /// <see cref="HandleBrokenStateAsync"/> via <see cref="GetAsync"/>, which reads the
+    /// state field once up-front and passes it as <c>observedState</c>. Forcing the real
+    /// state to <see cref="PoolState.Probing"/> after that read — the race path where
+    /// another caller won the CAS — requires coordinating two threads that deterministic
+    /// tests cannot reliably produce. This hook simulates the loser's observation by
+    /// calling the handler with <c>observedState = Broken</c> while the real state is
+    /// Probing; the <c>CompareExchange(Broken → Probing)</c> then correctly fails and the
+    /// handler throws the exhaustion exception.
+    /// </summary>
+    internal Task TestingInvokeHandleBrokenStateAsync(PoolState observedState, CancellationToken cancellationToken) =>
+        HandleBrokenStateAsync(observedState, cancellationToken);
 
     /// <inheritdoc />
     public ValueTask ReturnAsync(IRabbitMQChannel channel)
@@ -284,6 +366,7 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
 
         _exchangeDeclareLock.Dispose();
         _shutdownCts.Dispose();
+        _unhealthySignalCts.Dispose();
     }
 
     private async Task WarmUpAsync(int count, bool markOpenOnCompletion, CancellationToken cancellationToken)
@@ -361,6 +444,12 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                     // Only transition from Warming/Open; the probing path owns its own transitions.
                     _ = Interlocked.CompareExchange(ref _state, (int)PoolState.Broken, (int)PoolState.Warming);
                     _ = Interlocked.CompareExchange(ref _state, (int)PoolState.Broken, (int)PoolState.Open);
+
+                    // Wake any in-flight GetAsync waiters so they see Broken and route to
+                    // the failure listener rather than staying hung for the rest of the
+                    // outage. Must happen AFTER the state transition so the woken caller
+                    // observes Broken, not Warming.
+                    SignalUnhealthy();
                     return false;
                 }
 

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -65,7 +65,7 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     private readonly RabbitMQClientConfiguration _config;
     private readonly IRabbitMQConnectionFactory _connectionFactory;
     private readonly int _size;
-    private readonly int _maxRetries;
+    private readonly int? _maxRetries;
     private readonly Channel<IRabbitMQChannel> _channels;
     private readonly SemaphoreSlim _exchangeDeclareLock = new(1, 1);
     private readonly CancellationTokenSource _shutdownCts = new();
@@ -434,23 +434,31 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                 var failures = Interlocked.Increment(ref _consecutiveFailures);
                 SelfLog.WriteLine("Failed to warm up RabbitMQ channel (attempt {0}): {1}", failures, ex);
 
-                if (_maxRetries > 0 && failures >= _maxRetries)
+                if (_maxRetries is int maxRetries && failures >= maxRetries)
                 {
                     SelfLog.WriteLine(
                         "Channel pool exhausted after {0} consecutive warm-up failures; breaking for {1} ms.",
-                        _maxRetries,
+                        maxRetries,
                         BROKEN_COOLDOWN_MS);
                     Volatile.Write(ref _brokenUntilTicks, Stopwatch.GetTimestamp() + BROKEN_COOLDOWN_STOPWATCH_TICKS);
 
                     // Only transition from Warming/Open; the probing path owns its own transitions.
-                    _ = Interlocked.CompareExchange(ref _state, (int)PoolState.Broken, (int)PoolState.Warming);
-                    _ = Interlocked.CompareExchange(ref _state, (int)PoolState.Broken, (int)PoolState.Open);
+                    var previousState = Interlocked.CompareExchange(ref _state, (int)PoolState.Broken, (int)PoolState.Warming);
+                    if (previousState != (int)PoolState.Warming)
+                    {
+                        previousState = Interlocked.CompareExchange(ref _state, (int)PoolState.Broken, (int)PoolState.Open);
+                    }
 
-                    // Wake any in-flight GetAsync waiters so they see Broken and route to
-                    // the failure listener rather than staying hung for the rest of the
-                    // outage. Must happen AFTER the state transition so the woken caller
-                    // observes Broken, not Warming.
-                    SignalUnhealthy();
+                    // Only wake in-flight waiters if we actually caused the transition to
+                    // Broken. If state was Probing, a concurrent probe is mid-flight and
+                    // might still succeed — prematurely signalling unhealthy would wake
+                    // waiters who then throw exhausted, bypassing the probe's recovery.
+                    // If state was already Broken, the signal is a no-op anyway.
+                    if (previousState == (int)PoolState.Warming || previousState == (int)PoolState.Open)
+                    {
+                        SignalUnhealthy();
+                    }
+
                     return false;
                 }
 

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClientConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClientConfiguration.cs
@@ -107,6 +107,15 @@ public class RabbitMQClientConfiguration
     }
 
     /// <summary>
+    /// Maximum number of consecutive warm-up failures before the channel pool enters a
+    /// broken state and fails fast from <see cref="IRabbitMQChannelPool.GetAsync"/>.
+    /// A half-open circuit breaker attempts recovery after a cooldown window.
+    /// Default is 10. Set to 0 to retry indefinitely (preserves pre-9.0 behaviour).
+    /// The failure counter resets on any successful channel creation.
+    /// </summary>
+    public int WarmUpMaxRetries { get; set; } = 10;
+
+    /// <summary>
     /// Contains events for sending messages.
     /// </summary>
     public ISendMessageEvents? SendMessageEvents { get; set; }
@@ -126,6 +135,7 @@ public class RabbitMQClientConfiguration
             Heartbeat = Heartbeat,
             Hostnames = Hostnames.ToList(),
             ChannelCount = ChannelCount,
+            WarmUpMaxRetries = WarmUpMaxRetries,
             Password = Password,
             Port = Port,
             RoutingKey = RoutingKey,
@@ -146,7 +156,7 @@ public class RabbitMQClientConfiguration
     /// previously observed when the checks lived in <c>LoggerConfigurationRabbitMQExtensions</c>.
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <see cref="Hostnames"/> is null or empty, <see cref="Username"/> is null or empty, or <see cref="Password"/> is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="Port"/> is outside the valid TCP range or <see cref="ChannelCount"/> is not greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="Port"/> is outside the valid TCP range, <see cref="ChannelCount"/> is not greater than zero, or <see cref="WarmUpMaxRetries"/> is negative.</exception>
     [SuppressMessage(
         "Major Code Smell",
         "S3928:Parameter names used into ArgumentException constructors should match an existing one",
@@ -176,6 +186,11 @@ public class RabbitMQClientConfiguration
         if (ChannelCount <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(ChannelCount), "ChannelCount must be greater than zero.");
+        }
+
+        if (WarmUpMaxRetries < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(WarmUpMaxRetries), "WarmUpMaxRetries must be zero (unlimited) or positive.");
         }
     }
 }

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClientConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQClientConfiguration.cs
@@ -110,10 +110,10 @@ public class RabbitMQClientConfiguration
     /// Maximum number of consecutive warm-up failures before the channel pool enters a
     /// broken state and fails fast from <see cref="IRabbitMQChannelPool.GetAsync"/>.
     /// A half-open circuit breaker attempts recovery after a cooldown window.
-    /// Default is 10. Set to 0 to retry indefinitely (preserves pre-9.0 behaviour).
-    /// The failure counter resets on any successful channel creation.
+    /// Default is 10. Set to <see langword="null"/> to retry indefinitely (preserves
+    /// pre-9.0 behaviour). The failure counter resets on any successful channel creation.
     /// </summary>
-    public int WarmUpMaxRetries { get; set; } = 10;
+    public int? WarmUpMaxRetries { get; set; } = 10;
 
     /// <summary>
     /// Contains events for sending messages.
@@ -156,7 +156,7 @@ public class RabbitMQClientConfiguration
     /// previously observed when the checks lived in <c>LoggerConfigurationRabbitMQExtensions</c>.
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <see cref="Hostnames"/> is null or empty, <see cref="Username"/> is null or empty, or <see cref="Password"/> is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="Port"/> is outside the valid TCP range, <see cref="ChannelCount"/> is not greater than zero, or <see cref="WarmUpMaxRetries"/> is negative.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="Port"/> is outside the valid TCP range, <see cref="ChannelCount"/> is not greater than zero, or <see cref="WarmUpMaxRetries"/> is specified and not greater than zero.</exception>
     [SuppressMessage(
         "Major Code Smell",
         "S3928:Parameter names used into ArgumentException constructors should match an existing one",
@@ -188,9 +188,9 @@ public class RabbitMQClientConfiguration
             throw new ArgumentOutOfRangeException(nameof(ChannelCount), "ChannelCount must be greater than zero.");
         }
 
-        if (WarmUpMaxRetries < 0)
+        if (WarmUpMaxRetries is int retries && retries <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(WarmUpMaxRetries), "WarmUpMaxRetries must be zero (unlimited) or positive.");
+            throw new ArgumentOutOfRangeException(nameof(WarmUpMaxRetries), "WarmUpMaxRetries must be greater than zero, or null for unlimited retries.");
         }
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
@@ -94,7 +94,7 @@ namespace Serilog.Sinks.RabbitMQ
         public RabbitMQ.Client.SslOption? SslOption { get; set; }
         public string Username { get; set; }
         public string VHost { get; set; }
-        public int WarmUpMaxRetries { get; set; }
+        public int? WarmUpMaxRetries { get; set; }
         public Serilog.Sinks.RabbitMQ.RabbitMQClientConfiguration Clone() { }
         public void Validate() { }
     }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/Approval/Serilog.Sinks.RabbitMQ.approved.txt
@@ -94,6 +94,7 @@ namespace Serilog.Sinks.RabbitMQ
         public RabbitMQ.Client.SslOption? SslOption { get; set; }
         public string Username { get; set; }
         public string VHost { get; set; }
+        public int WarmUpMaxRetries { get; set; }
         public Serilog.Sinks.RabbitMQ.RabbitMQClientConfiguration Clone() { }
         public void Validate() { }
     }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -1265,10 +1265,11 @@ public class RabbitMQChannelPoolTests
     public async Task GetAsync_InFlightWaiter_WakesOnTransitionToBroken_AndRoutesToFallback()
     {
         // The key queue-bloat mitigation: a GetAsync parked on ReadAsync during the
-        // 62 s warm-up backoff window would otherwise stay hung for the entire
-        // outage, blocking BatchingSink's flush loop. When warm-up exhausts and
-        // transitions to Broken, the unhealthy signal fires and the in-flight waiter
-        // wakes, observes Broken, and throws the exhaustion exception so the batch
+        // cumulative warm-up backoff window (controlled by WarmUpMaxRetries and the
+        // backoff schedule) would otherwise stay hung for the entire outage,
+        // blocking BatchingSink's flush loop. When warm-up exhausts and transitions
+        // to Broken, the unhealthy signal fires and the in-flight waiter wakes,
+        // observes Broken, and throws the exhaustion exception so the batch
         // rethrows to BatchingSink's failure listener / Fallback chain.
         var connection = Substitute.For<IConnection>();
         connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading.Channels;
 
 using Serilog.Sinks.RabbitMQ.Tests.TestHelpers;
 
@@ -1333,6 +1334,132 @@ public class RabbitMQChannelPoolTests
 
         Volatile.Read(ref attempts).ShouldBe(attemptsAfterExhaustion);
         pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Broken);
+    }
+
+    [Fact]
+    public async Task SignalUnhealthy_SwallowsObjectDisposedException_WhenCtsAlreadyDisposed()
+    {
+        // Covers SignalUnhealthy's ObjectDisposedException catch. When DisposeAsync
+        // races with a warm-up exhaustion that is about to call SignalUnhealthy, the
+        // CTS has already been disposed and Cancel() throws ODE. The catch swallows
+        // so the ODE doesn't propagate into WarmUpSingleAsync's broad handler and
+        // light up SelfLog.
+        var connection = BuildConnectionWithChannelFactory(CreateOpenChannel);
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
+        var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await pool.DisposeAsync(); // disposes _unhealthySignalCts among other things
+
+        // Reach into the (now-disposed) pool and invoke SignalUnhealthy directly.
+        // Production reaches this via the exhaustion → signal path; reflection is
+        // how we deterministically hit the ODE branch without a multi-thread race.
+        var method = typeof(RabbitMQChannelPool).GetMethod("SignalUnhealthy", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("SignalUnhealthy not found.");
+
+        Should.NotThrow(() => method.Invoke(pool, null));
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenChannelsWriterCompletedWithoutDisposedFlag_ThrowsInvalidOperation()
+    {
+        // Covers the ChannelClosedException catch path in GetAsync. The normal
+        // disposal path short-circuits via the fast check at the top, so this
+        // catch only fires in the narrow window where DisposeAsync is mid-flight
+        // and has completed the writer without yet flipping the disposed flag.
+        // Reflection reproduces that window by completing the writer in place.
+        var connection = BuildConnectionWithChannelFactory(CreateOpenChannel);
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
+        var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
+
+        // Drain the pool so GetAsync would normally park on ReadAsync.
+        await pool.GetAsync();
+
+        // Complete the writer in place, without setting _disposed. GetAsync's fast
+        // path sees _disposed == 0 and falls through to ReadAsync, which throws
+        // ChannelClosedException on the completed writer.
+        var channelsField = typeof(RabbitMQChannelPool).GetField("_channels", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("_channels field not found.");
+        var channels = channelsField.GetValue(pool) as Channel<IRabbitMQChannel>
+            ?? throw new InvalidOperationException("_channels value was null.");
+        channels.Writer.TryComplete();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        ex.Message.ShouldContain("disposed");
+
+        // Pool field state is intentionally inconsistent post-test — no DisposeAsync
+        // to avoid spurious errors; SemaphoreSlim leak is acceptable in a test.
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenDisposedFlagSetDuringReadAsync_MapsCancellationToDisposal()
+    {
+        // Covers the OperationCanceledException catch whose when-filter reads the
+        // disposed flag. Like the writer-completed case above, this only fires in
+        // the narrow DisposeAsync race where the flag flips after the fast-path
+        // check but before the catch re-reads it. Reflection reproduces the exact
+        // state without needing a multi-thread race.
+        var connection = BuildConnectionWithChannelFactory(CreateOpenChannel);
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
+        var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
+        await pool.GetAsync(); // drain
+
+        using var cts = new CancellationTokenSource();
+        var parked = pool.GetAsync(cts.Token).AsTask();
+        await Task.Delay(50); // let parked call reach ReadAsync
+
+        // Flip _disposed without running the real DisposeAsync. The when-filter in
+        // GetAsync's catch re-reads this field when the OCE fires, and must see it
+        // set.
+        var disposedField = typeof(RabbitMQChannelPool).GetField("_disposed", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("_disposed field not found.");
+        disposedField.SetValue(pool, 1);
+
+        cts.Cancel();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await parked);
+        ex.Message.ShouldContain("disposed");
+
+        // Skip real DisposeAsync — _disposed is already set, Interlocked.Exchange
+        // would return non-zero and no-op. Test intentionally leaks the semaphore.
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenUnhealthySignalFiresButStateNotBroken_RethrowsOperationCanceled()
+    {
+        // Covers the `throw;` fallthrough in GetAsync's unhealthy-signal catch.
+        // SignalUnhealthy is only called from state-transition paths in production,
+        // so reaching this code requires _unhealthySignalCts to fire without a
+        // corresponding state transition — an atypical case used here to prove the
+        // catch doesn't mask a genuine cancellation as exhaustion.
+        var connection = BuildConnectionWithChannelFactory(CreateOpenChannel);
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
+        await pool.GetAsync(); // drain so GetAsync parks on ReadAsync
+
+        var parked = pool.GetAsync().AsTask();
+        await Task.Delay(50);
+
+        // Cancel the unhealthy CTS WITHOUT transitioning state.
+        var ctsField = typeof(RabbitMQChannelPool).GetField("_unhealthySignalCts", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("_unhealthySignalCts field not found.");
+        var cts = ctsField.GetValue(pool) as CancellationTokenSource
+            ?? throw new InvalidOperationException("_unhealthySignalCts value was null.");
+        cts.Cancel();
+
+        // Catch fires (linked cancelled, caller token not), state is Open, falls
+        // through to `throw;`. Caller sees OCE, not an exhaustion exception.
+        await Should.ThrowAsync<OperationCanceledException>(async () => await parked);
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Open);
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Diagnostics;
+using System.Reflection;
 
 using Serilog.Sinks.RabbitMQ.Tests.TestHelpers;
 
@@ -893,6 +894,273 @@ public class RabbitMQChannelPoolTests
         await disposed.Task;
 
         selfLogBuilder.ToString().ShouldNotContain(nameof(ObjectDisposedException));
+    }
+
+    // Issue #302: bounded warm-up + circuit breaker tests below.
+    private static readonly FieldInfo BrokenUntilTicksField =
+        typeof(RabbitMQChannelPool).GetField("_brokenUntilTicks", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("RabbitMQChannelPool._brokenUntilTicks field not found.");
+
+    private static void ExpireCooldown(RabbitMQChannelPool pool) =>
+        BrokenUntilTicksField.SetValue(pool, 0L);
+
+    [Theory]
+    [InlineData(1, 500)]
+    [InlineData(2, 1000)]
+    [InlineData(3, 2000)]
+    [InlineData(4, 4000)]
+    [InlineData(5, 8000)]
+    [InlineData(6, 16000)]
+    [InlineData(7, 30000)]
+    [InlineData(8, 30000)]
+    [InlineData(100, 30000)]
+    public void GetBackoffDelay_ReturnsExpectedSchedule(int failures, int expectedMilliseconds)
+    {
+        RabbitMQChannelPool.GetBackoffDelay(failures)
+            .ShouldBe(TimeSpan.FromMilliseconds(expectedMilliseconds));
+    }
+
+    [Fact]
+    public async Task WarmUp_StopsAfterMaxRetries_AndTransitionsToBroken()
+    {
+        // Arrange — every CreateChannelAsync attempt throws. With WarmUpMaxRetries=3 the
+        // warm-up loop should perform 3 attempts (because _consecutiveFailures resets only
+        // on success) and then transition the pool to Broken.
+        int attempts = 0;
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("permanent");
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 3,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+
+        Volatile.Read(ref attempts).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsExhausted_WhenPoolIsBroken()
+    {
+        int attempts = 0;
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("permanent");
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        ex.Message.ShouldContain("exhausted");
+        ex.Message.ShouldContain("2");
+    }
+
+    [Fact]
+    public async Task GetAsync_TriggersProbe_AfterCooldown_AndRecoversOnSuccess()
+    {
+        // Arrange — first 3 CreateChannelAsync calls fail (exhausting WarmUpMaxRetries=3
+        // and tripping Broken), from the 4th onwards the factory succeeds. Expiring the
+        // cooldown via reflection simulates the 60 s wall-clock wait without slowing the
+        // test; the probe attempt then succeeds and the pool transitions back to
+        // Warming → Open via the refill.
+        int attempts = 0;
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ =>
+            {
+                int attempt = Interlocked.Increment(ref attempts);
+                if (attempt <= 3)
+                {
+                    throw new InvalidOperationException("transient-broker-outage");
+                }
+
+                return Task.FromResult(CreateOpenChannel());
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 3,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+
+        // Act — expire cooldown so the next GetAsync tries to probe.
+        ExpireCooldown(pool);
+
+        // The probe succeeds, the caller falls through to ReadAsync, and the refill task
+        // eventually takes state back to Open.
+        var channel = await pool.GetAsync();
+        channel.ShouldNotBeNull();
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
+    }
+
+    [Fact]
+    public async Task GetAsync_ProbeFailure_RestoresBrokenStateWithFreshCooldown()
+    {
+        // Arrange — factory always fails. After exhaustion and cooldown expiry, the probe
+        // attempt must also fail, the pool must return to Broken with a NEW cooldown, and
+        // subsequent GetAsync calls must throw exhausted without re-probing.
+        int attempts = 0;
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("permanent");
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+        int attemptsAfterExhaustion = Volatile.Read(ref attempts);
+
+        ExpireCooldown(pool);
+
+        // First post-cooldown call triggers the probe. Probe fails → back to Broken.
+        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Broken);
+
+        // Probe used exactly one attempt on top of the pre-cooldown budget.
+        Volatile.Read(ref attempts).ShouldBe(attemptsAfterExhaustion + 1);
+
+        // Second post-cooldown call finds a FRESH cooldown and throws without probing.
+        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        Volatile.Read(ref attempts).ShouldBe(attemptsAfterExhaustion + 1);
+    }
+
+    [Fact]
+    public async Task GetAsync_ConcurrentCallsDuringProbe_AllSeeExhaustion()
+    {
+        // Arrange — first N calls fail to trip Broken; from N+1 onwards CreateChannelAsync
+        // blocks on a gate so the probe can be observed mid-flight. We then fire 4 concurrent
+        // GetAsync calls: one wins the CAS and becomes the probe, the others must all see
+        // Probing and throw exhausted immediately. After the gate releases, the probe
+        // succeeds and the winner's GetAsync returns a channel.
+        int attempts = 0;
+        var probeGate = new TaskCompletionSource<bool>();
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(async _ =>
+            {
+                int attempt = Interlocked.Increment(ref attempts);
+                if (attempt <= 2)
+                {
+                    throw new InvalidOperationException("permanent");
+                }
+
+                // Probe call: block until the test releases the gate.
+                await probeGate.Task.ConfigureAwait(false);
+                return CreateOpenChannel();
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+        ExpireCooldown(pool);
+
+        // Kick off four concurrent GetAsync calls; one becomes the probe.
+        var callers = Enumerable.Range(0, 4).Select(_ => Task.Run(async () =>
+        {
+            try
+            {
+                return await pool.GetAsync();
+            }
+            catch (InvalidOperationException)
+            {
+                return null!;
+            }
+        })).ToArray();
+
+        // Wait until the probe has entered CreateChannelAsync.
+        await WaitForAsync(() => Volatile.Read(ref attempts) >= 3);
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Probing);
+
+        // Let any concurrent callers finish their Broken/Probing checks.
+        await WaitForAsync(() => callers.Count(c => c.IsCompleted) >= 3);
+
+        // Now release the probe so the winning caller can complete.
+        probeGate.SetResult(true);
+
+        var results = await Task.WhenAll(callers);
+
+        // Exactly one caller got a channel; the rest threw (returned null in our wrapper).
+        results.Count(r => r is not null).ShouldBe(1);
+        results.Count(r => r is null).ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task ReturnAsync_Refill_WhenPoolBroken_AbortsWithoutMoreAttempts()
+    {
+        // Once the pool has transitioned to Broken, refills triggered by ReturnAsync must
+        // not keep hammering the broker — WarmUpSingleAsync's entry-check short-circuits
+        // so the circuit-breaker cooldown actually holds. Without the check, a cluster of
+        // simultaneously-broken channels would each spawn a refill task that ignored the
+        // breaker and piled up SelfLog spam.
+        int attempts = 0;
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("permanent");
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+        int attemptsAfterExhaustion = Volatile.Read(ref attempts);
+
+        // Simulate a broken channel return while the pool is Broken.
+        var brokenChannel = Substitute.For<IRabbitMQChannel>();
+        brokenChannel.IsOpen.Returns(false);
+        await pool.ReturnAsync(brokenChannel);
+
+        // Give the refill task time to have run if it were going to.
+        await Task.Delay(100);
+
+        Volatile.Read(ref attempts).ShouldBe(attemptsAfterExhaustion);
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Broken);
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -1125,6 +1125,178 @@ public class RabbitMQChannelPoolTests
     }
 
     [Fact]
+    public async Task GetAsync_ProbeInFlight_WhenPoolDisposed_DisposesOrphanChannelAndSurfacesDisposal()
+    {
+        // Covers HandleBrokenStateAsync's "TryWrite failed" branch: probe is inside
+        // CreateChannelAsync when the pool is disposed, so _channels.Writer is completed
+        // by the time the probe returns. The returned channel is orphaned and must be
+        // disposed; GetAsync's follow-on ReadAsync then surfaces the disposal.
+        int attempts = 0;
+        var probeGate = new TaskCompletionSource<bool>();
+        var probeChannel = Substitute.For<IChannel>();
+        probeChannel.IsOpen.Returns(true);
+
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(async _ =>
+            {
+                int attempt = Interlocked.Increment(ref attempts);
+                if (attempt <= 2)
+                {
+                    throw new InvalidOperationException("permanent");
+                }
+
+                await probeGate.Task.ConfigureAwait(false);
+                return probeChannel;
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+        ExpireCooldown(pool);
+
+        var probeCall = pool.GetAsync().AsTask();
+
+        // Wait until the probe has entered CreateChannelAsync (attempt 3).
+        await WaitForAsync(() => Volatile.Read(ref attempts) >= 3);
+
+        // Dispose the pool while the probe is blocked; the writer is completed so TryWrite
+        // fails when the probe eventually returns.
+        await pool.DisposeAsync();
+
+        // Release the probe — CreateChannelAsync returns, TryWrite fails, the orphan
+        // channel is disposed, HandleBrokenStateAsync returns without transitioning.
+        probeGate.SetResult(true);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await probeCall);
+        ex.Message.ShouldContain("disposed");
+        probeChannel.Received(1).Dispose();
+    }
+
+    [Fact]
+    public async Task GetAsync_ProbeInFlight_WhenCallerTokenCancelled_RestoresBrokenAndRethrows()
+    {
+        // Covers the caller-cancellation path in HandleBrokenStateAsync: the probe is
+        // awaiting connection.CreateChannelAsync with the caller's token. Cancelling the
+        // token causes the probe to throw OperationCanceledException, which the handler
+        // must route through RecordProbeFailure (resetting the cooldown) and rethrow.
+        int attempts = 0;
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(async call =>
+            {
+                int attempt = Interlocked.Increment(ref attempts);
+                if (attempt <= 2)
+                {
+                    throw new InvalidOperationException("permanent");
+                }
+
+                // Probe call: block on the caller's cancellation token so we can cancel
+                // the probe deterministically.
+                var ct = call.ArgAt<CancellationToken>(1);
+                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                return CreateOpenChannel();
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+        ExpireCooldown(pool);
+
+        using var cts = new CancellationTokenSource();
+        var probeCall = pool.GetAsync(cts.Token).AsTask();
+
+        await WaitForAsync(() => Volatile.Read(ref attempts) >= 3);
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Probing);
+
+        cts.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(async () => await probeCall);
+
+        // Probe caller's OCE must also flip the pool back to Broken with a fresh cooldown,
+        // so a follow-on caller sees exhaustion rather than falling through to ReadAsync.
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Broken);
+    }
+
+    [Fact]
+    public async Task HandleBrokenState_WhenCasLoses_ThrowsExhaustion()
+    {
+        // Covers the CAS-lost race in HandleBrokenStateAsync (line ~162): a caller reads
+        // state=Broken and enters the handler, but between the read and the
+        // CompareExchange(Broken → Probing) another caller wins the probe role. The loser
+        // must throw the exhaustion exception without running a second probe. Simulating
+        // the timing race deterministically in a multi-thread test is not reliable, so we
+        // use a narrow internal test hook that pre-sets state=Probing and invokes the
+        // handler with observedState=Broken — the CAS then correctly fails.
+        var connection = BuildConnectionWithChannelFactory(CreateOpenChannel);
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration { ChannelCount = 1, WarmUpMaxRetries = 2 };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        // Drive the pool into Probing (simulating the "other caller already won the CAS").
+        pool.TestingSetState(RabbitMQChannelPool.PoolState.Probing);
+
+        // Invoke the handler as if we had observed Broken a moment earlier — CAS loses.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await pool.TestingInvokeHandleBrokenStateAsync(
+                RabbitMQChannelPool.PoolState.Broken,
+                default));
+        ex.Message.ShouldContain("exhausted");
+
+        // State must be unchanged — we were not the probe owner, so we did not clear it.
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Probing);
+    }
+
+    [Fact]
+    public async Task GetAsync_InFlightWaiter_WakesOnTransitionToBroken_AndRoutesToFallback()
+    {
+        // The key queue-bloat mitigation: a GetAsync parked on ReadAsync during the
+        // 62 s warm-up backoff window would otherwise stay hung for the entire
+        // outage, blocking BatchingSink's flush loop. When warm-up exhausts and
+        // transitions to Broken, the unhealthy signal fires and the in-flight waiter
+        // wakes, observes Broken, and throws the exhaustion exception so the batch
+        // rethrows to BatchingSink's failure listener / Fallback chain.
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ => throw new InvalidOperationException("permanent"));
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        // Park a caller on ReadAsync BEFORE the pool has had time to reach Broken.
+        // Pool is Warming; pool is empty; caller blocks.
+        var waiter = pool.GetAsync().AsTask();
+        pool.CurrentState.ShouldNotBe(RabbitMQChannelPool.PoolState.Broken);
+
+        // Wait for warm-up to exhaust — this fires SignalUnhealthy after flipping state.
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
+
+        // The hung waiter should wake with the exhaustion exception (NOT OCE), proving
+        // the signal fired and the catch handler routed the cancellation to the batching
+        // layer's fallback path.
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await waiter);
+        ex.Message.ShouldContain("exhausted");
+    }
+
+    [Fact]
     public async Task ReturnAsync_Refill_WhenPoolBroken_AbortsWithoutMoreAttempts()
     {
         // Once the pool has transitioned to Broken, refills triggered by ReturnAsync must

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -1299,6 +1299,101 @@ public class RabbitMQChannelPoolTests
     }
 
     [Fact]
+    public async Task WarmUp_WithNullMaxRetries_KeepsRetrying_WithoutTransitioningToBroken()
+    {
+        // `WarmUpMaxRetries = null` is the opt-in for unlimited retries (pre-9.0 behaviour);
+        // covers the short-circuit arm of `_maxRetries is int maxRetries && failures >= maxRetries`
+        // where the pattern match fails. Warm-up must keep retrying with the exponential
+        // backoff rather than transitioning to Broken — no matter how many failures stack up.
+        var attempts = 0;
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw new InvalidOperationException("permanent");
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = null,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+
+        // Wait until warm-up has retried enough times that the default MaxRetries of 10
+        // would have tripped the breaker — confirms the null opt-out disables exhaustion
+        // entirely. Two attempts suffice given the backoff (~500 ms of wall-clock delay
+        // after the first failure).
+        await WaitForAsync(() => Volatile.Read(ref attempts) >= 2);
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Warming);
+    }
+
+    [Fact]
+    public async Task RefillExhaustion_DuringProbing_DoesNotPrematurelySignalUnhealthy()
+    {
+        // If a refill WarmUpAsync (spawned by ReturnAsync) is still looping when
+        // HandleBrokenStateAsync has flipped state to Probing, and the refill itself
+        // reaches _maxRetries, it must NOT signal unhealthy — a concurrent probe is
+        // mid-flight and prematurely waking waiters (who would then observe Probing
+        // and throw exhausted) bypasses the probe's recovery.
+        //
+        // The guard in WarmUpSingleAsync only calls SignalUnhealthy when one of the two
+        // Warming/Open→Broken CAS calls succeeds; if state was Probing, both fail and
+        // the signal is suppressed. This test uses TestingSetState to force the Probing
+        // state deterministically, then spawns a refill via ReturnAsync that will hit
+        // _maxRetries, and asserts the unhealthy CTS is never cancelled.
+        var attempts = 0;
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ =>
+            {
+                var attempt = Interlocked.Increment(ref attempts);
+                if (attempt == 1)
+                {
+                    // Initial warm-up succeeds so the pool reaches Open.
+                    return Task.FromResult(CreateOpenChannel());
+                }
+
+                throw new InvalidOperationException("transient");
+            });
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
+
+        // Simulate HandleBrokenStateAsync already owning the probe.
+        pool.TestingSetState(RabbitMQChannelPool.PoolState.Probing);
+
+        var ctsField = typeof(RabbitMQChannelPool).GetField("_unhealthySignalCts", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("_unhealthySignalCts field not found.");
+        var signalCts = ctsField.GetValue(pool) as CancellationTokenSource
+            ?? throw new InvalidOperationException("_unhealthySignalCts value was null.");
+        signalCts.IsCancellationRequested.ShouldBeFalse();
+
+        // Return a broken channel — spawns a refill WarmUpAsync that will keep failing.
+        var brokenChannel = Substitute.For<IRabbitMQChannel>();
+        brokenChannel.IsOpen.Returns(false);
+        await pool.ReturnAsync(brokenChannel);
+
+        // Wait until the refill has failed _maxRetries times plus the initial success.
+        await WaitForAsync(() => Volatile.Read(ref attempts) >= 1 + configuration.WarmUpMaxRetries!.Value);
+
+        // Give the exhaustion block a beat to run its CAS pair + guarded SignalUnhealthy.
+        await Task.Delay(50);
+
+        // State must still be Probing (both CAS no-op'd) and the signal must NOT have fired.
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Probing);
+        signalCts.IsCancellationRequested.ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task ReturnAsync_Refill_WhenPoolBroken_AbortsWithoutMoreAttempts()
     {
         // Once the pool has transitioned to Broken, refills triggered by ReturnAsync must

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQClientConfigurationTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQClientConfigurationTests.cs
@@ -138,11 +138,13 @@ public class RabbitMQClientConfigurationTests
     }
 
     [Theory]
+    [InlineData(0)]
     [InlineData(-1)]
     [InlineData(int.MinValue)]
-    public void Validate_Throws_WhenWarmUpMaxRetriesIsNegative(int maxRetries)
+    public void Validate_Throws_WhenWarmUpMaxRetriesIsNotPositive(int maxRetries)
     {
-        // 0 is valid (unlimited retries, preserves pre-9.0 behaviour); only negatives throw.
+        // null is valid (unlimited retries, preserves pre-9.0 behaviour); zero or
+        // negative throws because there must be at least one permitted retry.
         var sut = ValidSample();
         sut.WarmUpMaxRetries = maxRetries;
 
@@ -150,14 +152,23 @@ public class RabbitMQClientConfigurationTests
     }
 
     [Theory]
-    [InlineData(0)]
     [InlineData(1)]
     [InlineData(10)]
     [InlineData(int.MaxValue)]
-    public void Validate_DoesNotThrow_WhenWarmUpMaxRetriesIsNonNegative(int maxRetries)
+    public void Validate_DoesNotThrow_WhenWarmUpMaxRetriesIsPositive(int maxRetries)
     {
         var sut = ValidSample();
         sut.WarmUpMaxRetries = maxRetries;
+
+        Should.NotThrow(sut.Validate);
+    }
+
+    [Fact]
+    public void Validate_DoesNotThrow_WhenWarmUpMaxRetriesIsNull()
+    {
+        // Null opts into unlimited retries (pre-9.0 behaviour).
+        var sut = ValidSample();
+        sut.WarmUpMaxRetries = null;
 
         Should.NotThrow(sut.Validate);
     }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQClientConfigurationTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQClientConfigurationTests.cs
@@ -19,6 +19,7 @@ public class RabbitMQClientConfigurationTests
             RoutingKey = "log",
             DeliveryMode = RabbitMQDeliveryMode.NonDurable,
             ChannelCount = 65,
+            WarmUpMaxRetries = 15,
             Port = 5673,
             AutoCreateExchange = true,
             Heartbeat = 21,
@@ -134,6 +135,31 @@ public class RabbitMQClientConfigurationTests
         sut.ChannelCount = channelCount;
 
         Should.Throw<ArgumentOutOfRangeException>(sut.Validate).ParamName.ShouldBe("ChannelCount");
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void Validate_Throws_WhenWarmUpMaxRetriesIsNegative(int maxRetries)
+    {
+        // 0 is valid (unlimited retries, preserves pre-9.0 behaviour); only negatives throw.
+        var sut = ValidSample();
+        sut.WarmUpMaxRetries = maxRetries;
+
+        Should.Throw<ArgumentOutOfRangeException>(sut.Validate).ParamName.ShouldBe("WarmUpMaxRetries");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(int.MaxValue)]
+    public void Validate_DoesNotThrow_WhenWarmUpMaxRetriesIsNonNegative(int maxRetries)
+    {
+        var sut = ValidSample();
+        sut.WarmUpMaxRetries = maxRetries;
+
+        Should.NotThrow(sut.Validate);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #302.

`RabbitMQChannelPool` previously retried warm-up forever on a fixed 500 ms interval. Under a sustained broker outage that meant constant wake-ups, `SelfLog` flooded with "Failed to warm up RabbitMQ channel" entries, and callers blocked on `GetAsync` indefinitely because the pool never filled — while the batching queue grew in memory behind the hung `EmitBatchAsync`. This PR adds bounded retries with exponential backoff, a fail-fast `Broken` state, a half-open circuit breaker that self-heals after a cooldown, and wakes in-flight `ReadAsync` waiters when the breaker trips so the batching queue drains to the failure listener instead of growing indefinitely.

## Behaviour

### Exponential backoff with cap, reset on success

| Failure count | Delay before retry |
|---:|---|
| 1 | 500 ms |
| 2 | 1 s |
| 3 | 2 s |
| 4 | 4 s |
| 5 | 8 s |
| 6 | 16 s |
| 7+ | 30 s (cap) |

Counter resets to 0 on any successful channel creation — a single transient blip cannot combine with later failures to reach the cap.

### Bounded retries → `Broken` state

After `WarmUpMaxRetries` consecutive failures (default `10`), the pool transitions to `Broken` via atomic CAS. Total wall-clock time before declaring the pool broken depends on `WarmUpMaxRetries` and the backoff schedule — with the default of 10 retries and the cap at 30 s, the cumulative backoff before exhaustion is roughly ~2 minutes.

`GetAsync` on a broken pool throws `InvalidOperationException("Channel pool exhausted after N consecutive warm-up failures; broker is unreachable.")` immediately — no more blocking waiters. The exception propagates through `PublishAsync` → `EmitBatchAsync` → `BatchingSink`'s failure listener, so a `WriteTo.Fallback(...)` wrapper automatically routes failed events to the fallback sink rather than piling them up in the batching queue.

### Wake in-flight waiters on exhaustion

A `GetAsync` caller that parked on `_channels.Reader.ReadAsync` during the cumulative warm-up backoff (controlled by `WarmUpMaxRetries` + the backoff schedule — roughly ~2 minutes at defaults) would otherwise stay hung for the entire outage — `ReadAsync` is waiting for someone to write a channel, and transitioning state to `Broken` doesn't write anything. Because `BatchingSink` awaits `EmitBatchAsync` one batch at a time, a single hung call blocks the whole flush loop and the in-memory queue grows indefinitely.

An internal `CancellationTokenSource` (`_unhealthySignalCts`) is cancelled the moment the pool transitions to `Broken`. `GetAsync` links this with the caller's token so the parked `ReadAsync` wakes up, observes `Broken`, and throws the exhaustion exception. From that point on — including during the 60 s cooldown and all subsequent broken windows — **every batch** (queued and new) routes cleanly through the failure listener / `Fallback` chain.

On probe success, a fresh CTS is installed so subsequent waiters aren't immediately poisoned by the previous outage's signal.

### Half-open circuit breaker with self-heal

After a 60 s cooldown, the first `GetAsync` call claims the probe role via `Interlocked.CompareExchange(ref _state, Probing, Broken)`. Only one probe runs at a time; concurrent callers see `Probing` and throw exhausted. The probe runs a single warm-up:

- **Success**: transition `Probing → Warming`, swap in a fresh unhealthy-signal CTS, spawn full refill, caller continues to `ReadAsync`.
- **Failure**: return to `Broken` with a fresh 60 s cooldown; `SignalUnhealthy` fires again for any newly-parked waiters.

## Public API

New property:

```csharp
public class RabbitMQClientConfiguration
{
    /// Default: 10. Set to null for unlimited retries (pre-9.0 behaviour).
    public int? WarmUpMaxRetries { get; set; } = 10;
}
```

Validated in `RabbitMQClientConfiguration.Validate()` — rejects zero and negative values; null is permitted and means unlimited. Approval snapshot updated (+1 line).

Backoff schedule, 60 s cooldown, and the wake-on-broken signalling are **intentionally not configurable**. Exposing them opens up design-space we haven't paid for (retry-aware appsettings binding, cross-TFM schedule validation, etc.); promote later if a real use case appears.

## Implementation notes

- State machine: `internal enum PoolState { Warming, Open, Broken, Probing }`. `internal` so circuit-breaker tests can synchronise on state transitions without reflecting on an int backing field.
- State field is `int`-backed for `Interlocked` APIs. Transitions via `CompareExchange` or `Exchange` to keep them atomic and race-free.
- Cooldown tracked via `Stopwatch.GetTimestamp()` rather than `Environment.TickCount64` — `TickCount64` is .NET 5+ only, the package targets `netstandard2.0`.
- Refill warm-ups (spawned from `ReturnAsync`) observe the `Broken` state on entry and short-circuit, so a cluster of broken channels can't collectively keep hammering the broker past the exhaustion threshold.
- `GetAsync` has a post-disposal fast path to avoid `ObjectDisposedException` on `_unhealthySignalCts.Token` after `DisposeAsync` has run.
- `SignalUnhealthy` catches `ObjectDisposedException` to cover the narrow race where `DisposeAsync` runs concurrently with a warm-up exhaustion.
- `WarmUpSingleAsync`'s exhaustion branch captures the result of the two `Warming/Open → Broken` CAS calls and only invokes `SignalUnhealthy()` when one of them actually caused the transition. If the CAS pair ran while state was `Probing` (a refill reached exhaustion while a probe was mid-flight), the signal is suppressed so in-flight waiters aren't prematurely woken and thrown as exhausted while the probe still has a chance to recover.

## Tests

**Behaviour tests:**

- `GetBackoffDelay_ReturnsExpectedSchedule` — theory covering every documented delay step plus the cap.
- `WarmUp_StopsAfterMaxRetries_AndTransitionsToBroken` — pool exits warm-up after exactly `_maxRetries` attempts and flips to `Broken`.
- `GetAsync_ThrowsExhausted_WhenPoolIsBroken` — exception message contains "exhausted" and the retry count.
- `GetAsync_TriggersProbe_AfterCooldown_AndRecoversOnSuccess` — reflection expires the cooldown without a 60 s wall-clock wait; probe succeeds, pool transitions `Broken → Probing → Warming → Open`.
- `GetAsync_ProbeFailure_RestoresBrokenStateWithFreshCooldown` — caught a real implementation bug mid-review where a `catch (InvalidOperationException)` accidentally swallowed mock exceptions and skipped `RecordProbeFailure`.
- `GetAsync_ConcurrentCallsDuringProbe_AllSeeExhaustion` — 4 concurrent `GetAsync` calls against a gated probe; exactly one wins, the rest throw.
- `GetAsync_InFlightWaiter_WakesOnTransitionToBroken_AndRoutesToFallback` — parks a caller on `ReadAsync` during `Warming`, waits for exhaustion, asserts the parked caller surfaces `InvalidOperationException("exhausted")` rather than staying hung.
- `ReturnAsync_Refill_WhenPoolBroken_AbortsWithoutMoreAttempts` — refill short-circuits on `Broken` and doesn't keep hammering the broker.
- `WarmUp_WithNullMaxRetries_KeepsRetrying_WithoutTransitioningToBroken` — `WarmUpMaxRetries = null` disables exhaustion; warm-up keeps retrying through the backoff schedule and state stays `Warming`.
- `RefillExhaustion_DuringProbing_DoesNotPrematurelySignalUnhealthy` — forces the pool into `Probing`, triggers a refill via `ReturnAsync` that reaches `_maxRetries`, and asserts `_unhealthySignalCts` is NOT cancelled (the guard on `SignalUnhealthy` is what makes this pass).
- New `Validate` tests: rejects zero and negative; accepts positive / `int.MaxValue` / `null`.

**Defensive-race coverage tests** (white-box via reflection; each targets one specific branch that can only fire in narrow multi-thread race windows):

- `GetAsync_ProbeInFlight_WhenPoolDisposed_DisposesOrphanChannelAndSurfacesDisposal` — probe-in-flight + pool-disposed orphan path.
- `GetAsync_ProbeInFlight_WhenCallerTokenCancelled_RestoresBrokenAndRethrows` — caller-OCE during probe.
- `HandleBrokenState_WhenCasLoses_ThrowsExhaustion` — CAS-lost probe race via narrow internal test hook.
- `SignalUnhealthy_SwallowsObjectDisposedException_WhenCtsAlreadyDisposed` — race with `DisposeAsync`.
- `GetAsync_WhenChannelsWriterCompletedWithoutDisposedFlag_ThrowsInvalidOperation` — `ChannelClosedException` catch covering mid-`DisposeAsync` window.
- `GetAsync_WhenDisposedFlagSetDuringReadAsync_MapsCancellationToDisposal` — `OCE` catch whose when-filter re-reads `_disposed`.
- `GetAsync_WhenUnhealthySignalFiresButStateNotBroken_RethrowsOperationCanceled` — `throw;` fallthrough when `SignalUnhealthy` races the state transition.

## Test plan

- [x] `dotnet build -c Release --no-restore` — 0 warnings / 0 errors across `netstandard2.0`, `net8.0`, `net10.0` (+ `net48` for tests).
- [x] Unit tests on `net10.0` — 151 passed (was 125).
- [x] Unit tests on `net8.0` — 150 passed (was 123).
- [x] `dotnet format --no-restore --verify-no-changes --severity warn` — clean.
- [x] Coverage — 99.55 % line / 98.87 % branch overall. **0 uncovered sequence points** on `RabbitMQChannelPool` and `RabbitMQClientConfiguration`. Codecov/patch should report 100 % patch coverage.
- [x] Public API approval snapshot — updated (+1 line for `WarmUpMaxRetries`).
- [x] Windows CI validates net48.

## Non-goals

- Integration test against a real broker outage — covered by unit tests with reflected state + gated mocks. The integration suite continues to target the docker-compose broker for happy-path coverage.
- `IRabbitMQConnectionFactory` signature changes — out of scope.
- Exposing the backoff schedule / cooldown / signal as public config properties — intentionally kept as internal implementation details; promote later if a concrete use case surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

