### PR TITLE
Forward only the un-published tail of a failed batch to the failure sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,18 @@ Add `net9.0` to the target frameworks.
 
 ## 9.0.0 [not published]
 
+### Fixed partial-batch duplication when forwarding to a failure sink
+
+When a publish failed mid-batch (e.g. event 30 of 50 throws) the sink previously
+forwarded the entire batch to the configured failure sink — including the events
+that had already published successfully to the broker. Downstream consumers
+without `MessageId`-based idempotency would therefore see those leading events
+twice. `EmitBatchAsync` now tracks the index of the failing event and forwards
+only the un-published tail (failing event + remainder) to the failure sink.
+
+This applies to both wirings: the built-in `failureSinkConfiguration` parameter
+and `WriteTo.Fallback(...)` composition.
+
 ### Added support for .net 10
 
 Add `net10.0` to the target frameworks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,17 +117,22 @@ Add `net9.0` to the target frameworks.
 
 ## 9.0.0 [not published]
 
-### Fixed partial-batch duplication when forwarding to a failure sink
+### Fixed partial-batch duplication when forwarding to the in-sink failure sink
 
 When a publish failed mid-batch (e.g. event 30 of 50 throws) the sink previously
-forwarded the entire batch to the configured failure sink — including the events
-that had already published successfully to the broker. Downstream consumers
-without `MessageId`-based idempotency would therefore see those leading events
-twice. `EmitBatchAsync` now tracks the index of the failing event and forwards
-only the un-published tail (failing event + remainder) to the failure sink.
+forwarded the entire batch to the configured `failureSinkConfiguration` failure
+sink — including the events that had already published successfully to the
+broker. Downstream consumers without `MessageId`-based idempotency would
+therefore see those leading events twice. `EmitBatchAsync` now tracks the index
+of the failing event and forwards only the un-published tail (failing event +
+remainder) to the in-sink failure sink.
 
-This applies to both wirings: the built-in `failureSinkConfiguration` parameter
-and `WriteTo.Fallback(...)` composition.
+**Scope.** This narrowing applies only to the in-sink `failureSinkConfiguration`
+path. On the rethrow path, Serilog's `BatchingSink` hands its own copy of the
+original batch to its failure listener — so `WriteTo.Fallback(...)` wrappers
+still observe the full batch, not the tail. Surfacing the slice through
+`BatchingSink` would require an upstream contract change; tracked separately as
+[#318](https://github.com/ArieGato/serilog-sinks-rabbitmq/issues/318).
 
 ### Added support for .net 10
 

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -131,14 +131,29 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, ISetLogg
         // make sure we have an array to avoid multiple enumeration
         var logEvents = batch as LogEvent[] ?? batch.ToArray();
 
+        // Track the index we are about to publish so the catch can forward only the
+        // un-published tail to the failure sink. Forwarding the entire batch would
+        // duplicate every event that already published successfully (the broker
+        // accepted them, then a later event in the same batch failed) — downstream
+        // systems without idempotency on MessageId would see those duplicates.
+        int published = 0;
         try
         {
-            foreach (var logEvent in logEvents)
-                await EmitAsync(logEvent).ConfigureAwait(false);
+            for (; published < logEvents.Length; published++)
+            {
+                await EmitAsync(logEvents[published]).ConfigureAwait(false);
+            }
         }
         catch (Exception exception)
         {
-            if (!HandleException(exception, logEvents))
+            // logEvents[published] is the failing event; the slice [published..] is
+            // failing-plus-remainder, all of which are unpublished from the broker's
+            // perspective. logEvents[..published] succeeded and must not be re-emitted.
+            var unpublished = published == 0
+                ? logEvents
+                : logEvents.AsSpan(published).ToArray();
+
+            if (!HandleException(exception, unpublished))
             {
                 throw;
             }

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSink.cs
@@ -132,10 +132,16 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, ISetLogg
         var logEvents = batch as LogEvent[] ?? batch.ToArray();
 
         // Track the index we are about to publish so the catch can forward only the
-        // un-published tail to the failure sink. Forwarding the entire batch would
-        // duplicate every event that already published successfully (the broker
+        // un-published tail to the in-sink failure sink. Forwarding the entire batch
+        // would duplicate every event that already published successfully (the broker
         // accepted them, then a later event in the same batch failed) — downstream
         // systems without idempotency on MessageId would see those duplicates.
+        //
+        // Important scope: this slicing only reaches the configured `failureSinkConfiguration`
+        // sink (consumed inside HandleException). On the rethrow path Serilog's BatchingSink
+        // hands its OWN copy of the original batch to its failure listener, so wrappers like
+        // `WriteTo.Fallback(...)` still observe all M events, not the tail. Surfacing the
+        // slice through BatchingSink would require an upstream contract change — see #318.
         int published = 0;
         try
         {
@@ -214,18 +220,32 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, ISetLogg
     }
 
     /// <summary>
-    /// Handles the exceptions from <see cref="EmitBatchAsync"/>.
+    /// Handles the exceptions from <see cref="EmitBatchAsync"/>. Routes the failure to
+    /// SelfLog and/or the in-sink <c>failureSinkConfiguration</c> failure sink according
+    /// to <see cref="EmitEventFailureHandling"/>, and decides whether to swallow or
+    /// rethrow.
     /// </summary>
-    /// <param name="ex">Occurred exception.</param>
-    /// <param name="events">Batch of log events.</param>
+    /// <param name="ex">The exception thrown by <see cref="EmitAsync"/>.</param>
+    /// <param name="unpublishedEvents">
+    /// The failing event followed by every event in the batch that came after it — the
+    /// suffix that the broker did not accept. Events that already published successfully
+    /// in the same batch are not in this slice and must not be re-emitted to the
+    /// in-sink failure sink.
+    /// </param>
     /// <returns>
     /// <see langword="true"/> when the exception has been fully handled and must not be
-    /// rethrown (legacy catch-and-route). <see langword="false"/> when the caller should
-    /// rethrow so Serilog's <see cref="IBatchedLogEventSink"/> pipeline (typically
+    /// rethrown (legacy catch-and-route via <see cref="EmitEventFailureHandling.WriteToFailureSink"/>
+    /// without <see cref="EmitEventFailureHandling.ThrowException"/>). <see langword="false"/>
+    /// when the caller should rethrow.
+    ///
+    /// On rethrow Serilog's <see cref="IBatchedLogEventSink"/> pipeline (typically
     /// <c>BatchingSink</c>) observes the failure and routes it through its own listener
-    /// machinery — this is how <c>WriteTo.Fallback(...)</c> composes.
+    /// machinery — this is how <c>WriteTo.Fallback(...)</c> composes. Note that the
+    /// listener receives the ORIGINAL batch <c>BatchingSink</c> passed in, not the
+    /// <paramref name="unpublishedEvents"/> slice; the slicing only narrows what reaches
+    /// the in-sink failure sink. See issue #318.
     /// </returns>
-    private bool HandleException(Exception ex, LogEvent[] events)
+    private bool HandleException(Exception ex, LogEvent[] unpublishedEvents)
     {
         if (_emitEventFailureHandling.HasFlag(EmitEventFailureHandling.WriteToSelfLog))
         {
@@ -235,10 +255,12 @@ public sealed class RabbitMQSink : IBatchedLogEventSink, ILogEventSink, ISetLogg
 
         if (_emitEventFailureHandling.HasFlag(EmitEventFailureHandling.WriteToFailureSink) && _failureSink != null)
         {
-            // Send to a failure sink
+            // Send the un-published tail to the failure sink. Events that already
+            // published successfully in this batch are NOT in unpublishedEvents — they
+            // were sliced out in EmitBatchAsync's catch and must not be re-emitted.
             try
             {
-                foreach (var e in events)
+                foreach (var e in unpublishedEvents)
                 {
                     _failureSink.Emit(e);
                 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -285,6 +285,55 @@ public class RabbitMQSinkTests
     }
 
     [Fact]
+    public async Task EmitBatchAsync_ShouldOnlyForwardUnpublishedTailToFailureSink_WhenPublishFailsMidBatch()
+    {
+        // Partial-batch correctness: events that already published to the broker must
+        // NOT be re-emitted to the failure sink, otherwise downstream systems without
+        // MessageId-based idempotency would see duplicates (issue: P1 #6 architect
+        // review). Only the failing event and the events after it are un-published
+        // from the broker's perspective.
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+
+        // Succeed twice, then throw on the third PublishAsync.
+        var publishCalls = 0;
+        var rabbitMQClient = Substitute.For<IRabbitMQClient>();
+        rabbitMQClient.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>())
+            .Returns(_ =>
+            {
+                int call = Interlocked.Increment(ref publishCalls);
+                if (call >= 3)
+                {
+                    throw new InvalidOperationException("broker-failure");
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var failureSink = Substitute.For<ILogEventSink>();
+        var sut = new RabbitMQSink(rabbitMQClient, textFormatter, messageEvents, EmitEventFailureHandling.WriteToFailureSink, failureSink);
+
+        var logEvent1 = LogEventBuilder.Create().Build();
+        var logEvent2 = LogEventBuilder.Create().Build();
+        var logEvent3 = LogEventBuilder.Create().Build();
+        var logEvent4 = LogEventBuilder.Create().Build();
+        var logEvent5 = LogEventBuilder.Create().Build();
+
+        // Act
+        await sut.EmitBatchAsync([logEvent1, logEvent2, logEvent3, logEvent4, logEvent5]);
+
+        // Assert — events 1 and 2 published successfully and must NOT be forwarded.
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent1));
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent2));
+
+        // Events 3, 4, 5 were never published from the broker's perspective and
+        // must all be forwarded for the failure sink to surface durably.
+        failureSink.Received(1).Emit(Arg.Is(logEvent3));
+        failureSink.Received(1).Emit(Arg.Is(logEvent4));
+        failureSink.Received(1).Emit(Arg.Is(logEvent5));
+    }
+
+    [Fact]
     public async Task EmitBatchAsync_ShouldWriteAllEventsToFailureSink_WhenPublishThrowsException()
     {
         // Arrange

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -334,6 +334,159 @@ public class RabbitMQSinkTests
     }
 
     [Fact]
+    public async Task EmitBatchAsync_ShouldForwardOnlyLastEvent_WhenOnlyLastPublishFails()
+    {
+        // Boundary case for the partial-batch slicing: the failing event is the
+        // very last one, so the un-published tail contains exactly one element.
+        // Proves the slice is `[failingIndex..]` and not `[failingIndex+1..]`
+        // (off-by-one in the other direction would silently drop the failing event).
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+
+        var publishCalls = 0;
+        var rabbitMQClient = Substitute.For<IRabbitMQClient>();
+        rabbitMQClient.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>())
+            .Returns(_ =>
+            {
+                int call = Interlocked.Increment(ref publishCalls);
+                if (call == 5)
+                {
+                    throw new InvalidOperationException("broker-failure-on-last");
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var failureSink = Substitute.For<ILogEventSink>();
+        var sut = new RabbitMQSink(rabbitMQClient, textFormatter, messageEvents, EmitEventFailureHandling.WriteToFailureSink, failureSink);
+
+        var logEvent1 = LogEventBuilder.Create().Build();
+        var logEvent2 = LogEventBuilder.Create().Build();
+        var logEvent3 = LogEventBuilder.Create().Build();
+        var logEvent4 = LogEventBuilder.Create().Build();
+        var logEvent5 = LogEventBuilder.Create().Build();
+
+        // Act
+        await sut.EmitBatchAsync([logEvent1, logEvent2, logEvent3, logEvent4, logEvent5]);
+
+        // Assert — only the last (failing) event is forwarded.
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent1));
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent2));
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent3));
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent4));
+        failureSink.Received(1).Emit(Arg.Is(logEvent5));
+    }
+
+    [Fact]
+    public async Task EmitBatchAsync_ShouldForwardTailAndRethrow_WhenWriteToFailureSinkAndThrowExceptionAreSet()
+    {
+        // The "route to failure sink AND still throw" combination
+        // (WriteToFailureSink | ThrowException) must observe BOTH semantics on the
+        // same partial-batch slice: the un-published tail goes to the failure sink
+        // AND the original exception propagates so a Fallback wrapper / BatchingSink
+        // listener also sees the failure.
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+
+        var publishCalls = 0;
+        var rabbitMQClient = Substitute.For<IRabbitMQClient>();
+        rabbitMQClient.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>())
+            .Returns(_ =>
+            {
+                int call = Interlocked.Increment(ref publishCalls);
+                if (call >= 3)
+                {
+                    throw new InvalidOperationException("broker-failure");
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var failureSink = Substitute.For<ILogEventSink>();
+        var sut = new RabbitMQSink(
+            rabbitMQClient,
+            textFormatter,
+            messageEvents,
+            EmitEventFailureHandling.WriteToFailureSink | EmitEventFailureHandling.ThrowException,
+            failureSink);
+
+        var logEvent1 = LogEventBuilder.Create().Build();
+        var logEvent2 = LogEventBuilder.Create().Build();
+        var logEvent3 = LogEventBuilder.Create().Build();
+        var logEvent4 = LogEventBuilder.Create().Build();
+        var logEvent5 = LogEventBuilder.Create().Build();
+
+        // Act
+        var act = () => sut.EmitBatchAsync([logEvent1, logEvent2, logEvent3, logEvent4, logEvent5]);
+
+        // Assert — exception still propagates for downstream listeners.
+        var thrown = await Should.ThrowAsync<InvalidOperationException>(act);
+        thrown.Message.ShouldBe("broker-failure");
+
+        // Slicing applies independently of rethrow: only events 3-5 forwarded.
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent1));
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent2));
+        failureSink.Received(1).Emit(Arg.Is(logEvent3));
+        failureSink.Received(1).Emit(Arg.Is(logEvent4));
+        failureSink.Received(1).Emit(Arg.Is(logEvent5));
+    }
+
+    [Fact]
+    public async Task EmitBatchAsync_ShouldWriteSelfLogAndForwardTail_WhenWriteToSelfLogAndWriteToFailureSinkAreSet()
+    {
+        // WriteToSelfLog | WriteToFailureSink — the diagnostic flag on top of the
+        // failure-sink routing. Confirms both the SelfLog write and the partial-tail
+        // slicing coexist; without the ThrowException flag the legacy catch-and-route
+        // path applies and no exception escapes.
+        using var selfLog = new SelfLogScope(out var selfLogStringBuilder);
+
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+
+        var publishCalls = 0;
+        var rabbitMQClient = Substitute.For<IRabbitMQClient>();
+        rabbitMQClient.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>())
+            .Returns(_ =>
+            {
+                int call = Interlocked.Increment(ref publishCalls);
+                if (call >= 3)
+                {
+                    throw new InvalidOperationException("broker-failure");
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var failureSink = Substitute.For<ILogEventSink>();
+        var sut = new RabbitMQSink(
+            rabbitMQClient,
+            textFormatter,
+            messageEvents,
+            EmitEventFailureHandling.WriteToSelfLog | EmitEventFailureHandling.WriteToFailureSink,
+            failureSink);
+
+        var logEvent1 = LogEventBuilder.Create().Build();
+        var logEvent2 = LogEventBuilder.Create().Build();
+        var logEvent3 = LogEventBuilder.Create().Build();
+        var logEvent4 = LogEventBuilder.Create().Build();
+        var logEvent5 = LogEventBuilder.Create().Build();
+
+        // Act
+        await sut.EmitBatchAsync([logEvent1, logEvent2, logEvent3, logEvent4, logEvent5]);
+
+        // Assert — SelfLog received the exception summary.
+        selfLogStringBuilder.Length.ShouldBeGreaterThan(0);
+        selfLogStringBuilder.ToString().ShouldContain("broker-failure");
+
+        // And only events 3-5 forwarded.
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent1));
+        failureSink.DidNotReceive().Emit(Arg.Is(logEvent2));
+        failureSink.Received(1).Emit(Arg.Is(logEvent3));
+        failureSink.Received(1).Emit(Arg.Is(logEvent4));
+        failureSink.Received(1).Emit(Arg.Is(logEvent5));
+    }
+
+    [Fact]
     public async Task EmitBatchAsync_ShouldWriteAllEventsToFailureSink_WhenPublishThrowsException()
     {
         // Arrange

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQSinkTests.cs
@@ -285,6 +285,61 @@ public class RabbitMQSinkTests
     }
 
     [Fact]
+    public async Task EmitBatchAsync_ShouldRethrowOriginalException_WhenWriteToSelfLogAndThrowExceptionAreSetOnPartialBatch()
+    {
+        // No failure sink configured: WriteToSelfLog + ThrowException is the diagnostic-
+        // only-then-rethrow path. On a partial-batch failure the slicing computed inside
+        // EmitBatchAsync is not consumed by anything (no failure sink to receive it),
+        // and the rethrown exception must be the ORIGINAL instance — preserved via
+        // `throw;` so the stack walks back to the failing PublishAsync. SelfLog should
+        // record one diagnostic line containing the exception text.
+        using var selfLog = new SelfLogScope(out var selfLogStringBuilder);
+
+        var textFormatter = Substitute.For<ITextFormatter>();
+        var messageEvents = Substitute.For<ISendMessageEvents>();
+
+        var publishCalls = 0;
+        var brokerFailure = new InvalidOperationException("broker-failure");
+        var rabbitMQClient = Substitute.For<IRabbitMQClient>();
+        rabbitMQClient.PublishAsync(Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<BasicProperties>(), Arg.Any<string?>())
+            .Returns(_ =>
+            {
+                int call = Interlocked.Increment(ref publishCalls);
+                if (call >= 3)
+                {
+                    throw brokerFailure;
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var sut = new RabbitMQSink(
+            rabbitMQClient,
+            textFormatter,
+            messageEvents,
+            EmitEventFailureHandling.WriteToSelfLog | EmitEventFailureHandling.ThrowException,
+            failureSink: null);
+
+        var logEvent1 = LogEventBuilder.Create().Build();
+        var logEvent2 = LogEventBuilder.Create().Build();
+        var logEvent3 = LogEventBuilder.Create().Build();
+        var logEvent4 = LogEventBuilder.Create().Build();
+        var logEvent5 = LogEventBuilder.Create().Build();
+
+        // Act
+        var act = () => sut.EmitBatchAsync([logEvent1, logEvent2, logEvent3, logEvent4, logEvent5]);
+
+        // Assert — the original exception instance propagates (referential equality, not just
+        // type/message match). `throw;` preserves the stack; `throw ex` would not.
+        var thrown = await Should.ThrowAsync<InvalidOperationException>(act);
+        thrown.ShouldBeSameAs(brokerFailure);
+
+        // SelfLog received the diagnostic line.
+        selfLogStringBuilder.Length.ShouldBeGreaterThan(0);
+        selfLogStringBuilder.ToString().ShouldContain("broker-failure");
+    }
+
+    [Fact]
     public async Task EmitBatchAsync_ShouldOnlyForwardUnpublishedTailToFailureSink_WhenPublishFailsMidBatch()
     {
         // Partial-batch correctness: events that already published to the broker must


### PR DESCRIPTION
Fixes #311. Follow-up tracked as #318.

## Summary

When a batch publish fails mid-batch, `EmitBatchAsync` previously routed the entire batch to the configured `failureSinkConfiguration` failure sink — including the events that already published successfully to RabbitMQ before the failure. Downstream consumers without `MessageId`-based idempotency would see those leading events twice.

The catch in `EmitBatchAsync` now tracks the index of the failing event and forwards only `events[failedIndex..]` (failing event + remainder, none of which reached the broker) to the in-sink failure sink. Events that succeeded earlier in the same batch are not re-emitted.

## Scope — what this PR fixes vs. what it doesn't

This narrowing applies to the **in-sink `failureSinkConfiguration` path only**.

**Not fixed by this PR**: on the rethrow path (e.g. when wrapping the sink with `WriteTo.Fallback(...)`), Serilog's `BatchingSink` hands its own copy of the original batch to its failure listener. The unpublished slice computed inside `EmitBatchAsync` is discarded by `throw;` and never reaches the listener. So a `WriteTo.Fallback` wrapper still receives all M events, not the tail. Surfacing the slice through `BatchingSink` would require an upstream contract change — tracked as #318.

Recommendation for users who need partial-batch correctness today: prefer `failureSinkConfiguration` (with a custom `ILogEventSink`) over `WriteTo.Fallback` until #318 lands.

## Test coverage

Five tests in `RabbitMQSinkTests` covering the slicing on the in-sink path:

- `EmitBatchAsync_ShouldOnlyForwardUnpublishedTailToFailureSink_WhenPublishFailsMidBatch` — succeed 2×, throw on 3rd of 5; assert events 1-2 NOT forwarded and 3-5 each received once.
- `EmitBatchAsync_ShouldForwardOnlyLastEvent_WhenOnlyLastPublishFails` — boundary: failing event = last; slice has exactly one element.
- `EmitBatchAsync_ShouldForwardTailAndRethrow_WhenWriteToFailureSinkAndThrowExceptionAreSet` — slicing applies independently of the rethrow path (`WriteToFailureSink | ThrowException`).
- `EmitBatchAsync_ShouldWriteSelfLogAndForwardTail_WhenWriteToSelfLogAndWriteToFailureSinkAreSet` — SelfLog diagnostic write coexists with partial-tail forwarding.
- `EmitBatchAsync_ShouldRethrowOriginalException_WhenWriteToSelfLogAndThrowExceptionAreSetOnPartialBatch` — `WriteToSelfLog | ThrowException` on a partial batch (no failure sink); asserts the rethrown exception is the ORIGINAL instance (via `ShouldBeSameAs`, proving `throw;` preserved the stack rather than `throw ex` re-raising).

The existing `EmitBatchAsync_ShouldWriteAllEventsToFailureSink_WhenPublishThrowsException` continues to cover the `published == 0` short-circuit (every publish throws → slice is the full batch).

## Test plan

- [x] `dotnet build -c Release` clean across `netstandard2.0`, `net8.0`, `net10.0` (and `net48` for tests on Windows targets)
- [x] Full unit test suite passes on `net10.0` (156/156) and `net8.0` (155/155)
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [ ] Integration tests against `docker compose` brokers (not affected by this change but worth a smoke pass before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)