### PR TITLE
Reset _consecutiveFailures per cohort instead of per channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,23 @@ Add `net9.0` to the target frameworks.
 
 ## 9.0.0 [not published]
 
+### Fixed `_consecutiveFailures` per-channel reset masking sustained flapping
+
+The warm-up loop previously reset `_consecutiveFailures` to zero on every successful
+channel addition. A flaky broker that let one channel through per cohort therefore
+silently kept clearing the counter mid-cohort and never reached `WarmUpMaxRetries`,
+so the breaker never tripped — even with cumulative failures well past the
+configured budget. The reset now happens on **cohort completion** (in `WarmUpAsync`,
+after the inner loop), so failures accumulate across the cohort while still letting
+a clean refill or initial warm-up clear stale failure history from a previous
+outage. The previously-skipped reproducer test
+`WarmUp_WithFlakyBrokerOneSuccessPerCohort_TripsBrokenAfterMaxRetriesCumulativeFailures`
+is now passing. Tracked as [#315](https://github.com/ArieGato/serilog-sinks-rabbitmq/issues/315).
+
+This is a behaviour change for users with `WarmUpMaxRetries` set: a sustained
+flapping pattern that previously kept the breaker dormant will now correctly trip
+it once the cumulative-failure threshold is reached.
+
 ### Wired `warmUpMaxRetries` through the public extension overloads
 
 `WriteTo.RabbitMQ(...)` and `AuditTo.RabbitMQ(...)` now expose a `warmUpMaxRetries`

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -424,6 +424,16 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             }
         }
 
+        // Whole cohort succeeded: every requested channel was opened and added to the
+        // pool. Reset the consecutive-failure counter HERE rather than per-channel
+        // inside WarmUpSingleAsync — otherwise a flaky broker that lets one channel
+        // through per cohort would silently keep clearing the counter mid-cohort and
+        // never reach WarmUpMaxRetries (issue #315). Resetting on cohort completion
+        // preserves the contract "after N consecutive warm-up failures the breaker
+        // trips" while still letting a clean refill or initial warm-up clear stale
+        // failure history from a previous outage.
+        Volatile.Write(ref _consecutiveFailures, 0);
+
         if (markOpenOnCompletion)
         {
             // Full warm-up completed. Only advance Warming → Open; callers in Broken or
@@ -463,10 +473,9 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
                     return false;
                 }
 
-                // Any successful channel addition resets the consecutive-failure counter,
-                // so a single transient blip cannot combine with later failures to reach
-                // WarmUpMaxRetries.
-                Volatile.Write(ref _consecutiveFailures, 0);
+                // Per-channel success no longer resets _consecutiveFailures —
+                // WarmUpAsync resets it on full-cohort completion instead. See the
+                // comment in WarmUpAsync for the rationale (issue #315).
                 return true;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -1694,21 +1694,19 @@ public class RabbitMQChannelPoolTests
         pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Open);
     }
 
-    [Fact(Skip = "P0 #3: _consecutiveFailures is reset on every individual successful channel add, so a flaky broker that lets one channel through per cohort never trips the breaker even past WarmUpMaxRetries cumulative failures. Confirmed failing — breaker never trips. Whether to fix vs. document is a design call.")]
+    [Fact]
     public async Task WarmUp_WithFlakyBrokerOneSuccessPerCohort_TripsBrokenAfterMaxRetriesCumulativeFailures()
     {
-        // Pattern: every odd attempt fails, every even attempt succeeds. With
-        // ChannelCount=4 and WarmUpMaxRetries=3, cohorts run:
-        //   cohort 0: fail, success (failures=1, reset to 0)
-        //   cohort 1: fail, success (failures=1, reset to 0)
-        //   cohort 2: fail, success (failures=1, reset to 0)
-        //   cohort 3: fail, success (failures=1, reset to 0)
-        // Total: 4 failures, none "consecutive" by the current definition — pool
-        // reaches Open. A user who set WarmUpMaxRetries=3 reasonably expects the
-        // breaker to trip after 3 cumulative warm-up failures.
-        //
-        // After the fix (track failures per cohort or only reset on full warm-up
-        // completion), state should transition to Broken before reaching Open.
+        // Issue #315: per-channel reset of _consecutiveFailures used to mask
+        // sustained flapping. Pattern: every odd attempt fails, every even attempt
+        // succeeds. With ChannelCount=4 and WarmUpMaxRetries=3, cohorts run:
+        //   cohort 0 (channel 0): fail (failures=1), success → return true
+        //   cohort 1 (channel 1): fail (failures=2), success → return true
+        //   cohort 2 (channel 2): fail (failures=3 ≥ maxRetries) → trip Broken
+        // The fix moves the reset from per-channel (in WarmUpSingleAsync) to
+        // per-cohort (in WarmUpAsync) so failures accumulate across the cohort
+        // and the breaker fires after WarmUpMaxRetries cumulative failures, as
+        // documented.
         int attempts = 0;
         var connection = Substitute.For<IConnection>();
         connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
@@ -1734,5 +1732,6 @@ public class RabbitMQChannelPoolTests
         await WaitForAsync(
             () => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken,
             TimeSpan.FromSeconds(5));
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Broken);
     }
 }


### PR DESCRIPTION
Fixes #315.

## Stacking note

This PR targets `warmup-backoff-and-circuit-breaker` (PR #310) rather than `master` because the bug exists in code introduced by #310 and is not yet on `master`. Merge #310 first, then this rebases onto `master` and merges.

## Summary

`WarmUpSingleAsync` previously reset `_consecutiveFailures` to zero on every successful channel addition. Under sustained flapping (broker lets one channel through per cohort, fails the next attempt) the counter was silently cleared mid-cohort and never reached `WarmUpMaxRetries` — so the breaker never tripped, even with cumulative failures well past the configured budget.

The reset now happens in `WarmUpAsync` once the inner loop has produced every requested channel, so failures accumulate across the cohort while still letting a clean refill or initial warm-up clear stale failure history from a previous outage.

## Trace (with `ChannelCount=4`, `WarmUpMaxRetries=3`, flaky pattern)

Pattern: every odd `CreateChannelAsync` throws, every even succeeds.

**Before fix:**

| Cohort | Attempts | `_consecutiveFailures` after |
|---|---|---|
| 0 (channel 0) | fail (=1), success (=0) | 0 |
| 1 (channel 1) | fail (=1), success (=0) | 0 |
| 2 (channel 2) | fail (=1), success (=0) | 0 |
| 3 (channel 3) | fail (=1), success (=0) | 0 |

Total failures = 4, none ever ≥ 3, breaker dormant. Pool reaches `Open`.

**After fix:**

| Cohort | Attempts | `_consecutiveFailures` after |
|---|---|---|
| 0 (channel 0) | fail (=1), success | **1** (no per-channel reset) |
| 1 (channel 1) | fail (=2), success | **2** |
| 2 (channel 2) | fail (=3 ≥ maxRetries) → trip Broken | (return false) |

Breaker fires after 3 cumulative failures, as documented.

## Behaviour change

Users with `WarmUpMaxRetries` set will see the breaker trip on flapping patterns that previously kept it dormant. Documented in the CHANGELOG.

The "single transient blip during warm-up doesn't trip the breaker" guarantee is preserved as long as the cohort completes — when `WarmUpAsync` returns successfully, `_consecutiveFailures` is reset to 0 before the next cohort starts.

## Test coverage

The previously-skipped `WarmUp_WithFlakyBrokerOneSuccessPerCohort_TripsBrokenAfterMaxRetriesCumulativeFailures` is un-skipped and now passes. It is the canonical reproducer for #315.

Existing tests covering the breaker / recovery paths continue to pass:
- `WarmUp_StopsAfterMaxRetries_AndTransitionsToBroken` — all-fail trip
- `GetAsync_TriggersProbe_AfterCooldown_AndRecoversOnSuccess` — probe recovery
- `WarmUp_WithNullMaxRetries_KeepsRetrying_WithoutTransitioningToBroken` — opt-out
- `RefillExhaustion_DuringProbing_DoesNotPrematurelySignalUnhealthy` — race suppression

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs
- [x] Full unit test suite passes on `net10.0` (154/154) and `net8.0` (153/153) — the formerly-skipped test is now part of the green count
- [x] `dotnet format --verify-no-changes --severity warn` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)