### PR TITLE
Post-310 cleanup: address #314, #316, #317

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,28 @@ Add `net9.0` to the target frameworks.
 
 ## 9.0.0 [not published]
 
+### Cleanup follow-ups from PR #310 architect review
+
+Three issues filed during the PR #310 review, addressed together:
+
+- **#314**: `GetAsync`'s rotation-race ODE handler (now in `ResolveUnhealthyToken`)
+  used to throw `InvalidOperationException("Channel pool has been disposed.")`
+  when the inner re-read also threw `ObjectDisposedException`, even if the pool
+  wasn't actually disposed. The handler now checks `_disposed` first and only
+  surfaces the disposal message when the flag is set; the (essentially-unreachable)
+  back-to-back rotation case maps to the structured `PoolExhaustedException`
+  instead.
+- **#316**: The internal `TestingSetState` and `TestingInvokeHandleBrokenStateAsync`
+  hooks are now `[Obsolete]`, so any accidental call from production code in
+  `src/` fails the build via the project-wide `TreatWarningsAsErrors`. The test
+  file suppresses CS0618 with a file-scope `#pragma`. The conditional-compilation
+  suggestion from the original review (`[Conditional("DEBUG")]` / `#if DEBUG`)
+  did not fit because tests run in `Release` on CI.
+- **#317**: New `ProbeRecovery_WithChannelCountOne_RefillCohortOfZeroReachesOpenState`
+  test pins the `ChannelCount = 1` edge case after the `_size - 1` refill fix —
+  the cohort of zero never enters the `WarmUpAsync` for-loop and must still
+  reach `Open` via the post-loop `Warming → Open` CAS.
+
 ### Gated cohort-completion `_consecutiveFailures` reset to authoritative cohorts
 
 After moving the consecutive-failure reset from per-channel to per-cohort (#315),

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQChannelPool.cs
@@ -118,7 +118,11 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     /// <summary>
     /// Test-only setter for the state field. Used by the CAS-lost probe-race test to
     /// force an atypical state/observedState divergence; not wired up in production.
+    /// Marked <see cref="ObsoleteAttribute"/> so any accidental call from
+    /// <c>src/</c> fails the build via <c>TreatWarningsAsErrors</c>; tests suppress
+    /// with <c>#pragma warning disable CS0618</c>.
     /// </summary>
+    [Obsolete("Test-only hook. Do not call from production code.", error: false)]
     internal void TestingSetState(PoolState state) => Volatile.Write(ref _state, (int)state);
 
     /// <inheritdoc />
@@ -223,7 +227,15 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
             }
             catch (ObjectDisposedException)
             {
-                throw new InvalidOperationException(POOL_DISPOSED_MESSAGE);
+                // If the pool is actually disposed (DisposeAsync sets _disposed
+                // BEFORE disposing _unhealthySignalCts), surface the structured
+                // disposal exception. Otherwise this is two consecutive rotation
+                // races in our snapshot/re-read window — essentially unreachable
+                // (#314); mapping it to "exhausted" instead of a misleading
+                // "disposed" message keeps the diagnostic accurate.
+                throw Volatile.Read(ref _disposed) != 0
+                    ? new InvalidOperationException(POOL_DISPOSED_MESSAGE)
+                    : PoolExhaustedException();
             }
         }
     }
@@ -342,7 +354,11 @@ internal sealed class RabbitMQChannelPool : IRabbitMQChannelPool
     /// calling the handler with <c>observedState = Broken</c> while the real state is
     /// Probing; the <c>CompareExchange(Broken → Probing)</c> then correctly fails and the
     /// handler throws the exhaustion exception.
+    /// Marked <see cref="ObsoleteAttribute"/> so any accidental call from
+    /// <c>src/</c> fails the build via <c>TreatWarningsAsErrors</c>; tests suppress
+    /// with <c>#pragma warning disable CS0618</c>.
     /// </summary>
+    [Obsolete("Test-only hook. Do not call from production code.", error: false)]
     internal Task TestingInvokeHandleBrokenStateAsync(PoolState observedState, CancellationToken cancellationToken) =>
         HandleBrokenStateAsync(observedState, cancellationToken);
 

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -1705,7 +1705,15 @@ public class RabbitMQChannelPoolTests
         // After the fix, this should map to a structured failure type
         // (InvalidOperationException for "disposed" or "exhausted") or succeed —
         // but never leak ObjectDisposedException to the caller.
+        //
+        // Additionally pin the #314 branch: with the CTS disposed but _disposed == 0
+        // (we only disposed the CTS via reflection, not the pool), the inner ODE
+        // catch in ResolveUnhealthyToken must throw the exhaustion exception
+        // ("Channel pool exhausted ...") rather than the misleading "disposed"
+        // message. If we ever see the disposed message here, the #314 fix has
+        // regressed.
         ObjectDisposedException? leaked = null;
+        InvalidOperationException? wrongDisposedMessage = null;
         try
         {
             using var callerCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
@@ -1715,10 +1723,15 @@ public class RabbitMQChannelPoolTests
         {
             leaked = ode;
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex) when (ex.Message.Contains("exhausted"))
         {
-            // Pool maps disposed CTS to "pool has been disposed" via the structured
-            // catch in GetAsync — that's the desired path, not a leak.
+            // Desired path: rotation race resolved as exhaustion (#314).
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("disposed"))
+        {
+            // Should not occur here — the pool itself is not disposed (only the
+            // CTS field was disposed via reflection). #314 regression marker.
+            wrongDisposedMessage = ex;
         }
         catch (OperationCanceledException)
         {
@@ -1727,6 +1740,10 @@ public class RabbitMQChannelPoolTests
         }
 
         leaked.ShouldBeNull();
+        wrongDisposedMessage.ShouldBeNull(
+            wrongDisposedMessage is null
+                ? null
+                : $"#314 regressed: rotation race produced 'disposed' message even though _disposed == 0. Got: {wrongDisposedMessage.Message}");
     }
 
     [Fact]

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -18,6 +18,13 @@ using System.Threading.Channels;
 
 using Serilog.Sinks.RabbitMQ.Tests.TestHelpers;
 
+// CS0618: TestingSetState / TestingInvokeHandleBrokenStateAsync are marked
+// [Obsolete] so any accidental call from production code fails the build via
+// TreatWarningsAsErrors. They are still the only deterministic way to drive
+// the CAS-lost probe race and a few state-machine tests; suppress the warning
+// here so legitimate test usages compile. Documented in #316.
+#pragma warning disable CS0618
+
 namespace Serilog.Sinks.RabbitMQ.Tests.RabbitMQ;
 
 [Collection("SelfLog")]
@@ -1777,6 +1784,42 @@ public class RabbitMQChannelPoolTests
         // With the bug present this WaitForAsync times out: refill orphans the (_size)th
         // channel, returns false from WarmUpSingleAsync, and exits before reaching the
         // Warming → Open CAS. State stays Warming.
+        await WaitForAsync(
+            () => pool.CurrentState == RabbitMQChannelPool.PoolState.Open,
+            TimeSpan.FromSeconds(3));
+        pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Open);
+    }
+
+    [Fact]
+    public async Task ProbeRecovery_WithChannelCountOne_RefillCohortOfZeroReachesOpenState()
+    {
+        // Issue #317: edge case for the `_size - 1` refill math after probe success.
+        // With ChannelCount=1, the probe writes the single channel and refill spawns
+        // WarmUpAsync(0, markOpenOnCompletion: true). The for loop body never runs;
+        // the post-loop block fires the cohort-completion reset (a no-op since no
+        // failures accumulated) and CAS's Warming → Open. End-state must be Open.
+        var connection = Substitute.For<IConnection>();
+        connection.CreateChannelAsync(Arg.Any<CreateChannelOptions?>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IChannel>>(_ => Task.FromResult(CreateOpenChannel()));
+        var connectionFactory = BuildConnectionFactory(connection);
+        var configuration = new RabbitMQClientConfiguration
+        {
+            ChannelCount = 1,
+            WarmUpMaxRetries = 2,
+        };
+
+        await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
+        await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
+
+        // Drain so probe writes into an empty queue — same approach as the
+        // ChannelCount > 1 sibling test.
+        await pool.GetAsync();
+
+        pool.TestingSetState(RabbitMQChannelPool.PoolState.Broken);
+        ExpireCooldown(pool);
+
+        await pool.TestingInvokeHandleBrokenStateAsync(RabbitMQChannelPool.PoolState.Broken, default);
+
         await WaitForAsync(
             () => pool.CurrentState == RabbitMQChannelPool.PoolState.Open,
             TimeSpan.FromSeconds(3));


### PR DESCRIPTION
Bundles three small follow-ups filed during the PR #310 architect review. None individually warrant a PR; together they're small enough to review at a glance.

Closes #314, #316, #317.

## #314 — `ResolveUnhealthyToken` inner ODE catch mislabels rotation race as 'pool disposed'

The inner ODE catch (now in the `[ExcludeFromCodeCoverage]` helper) used to throw `InvalidOperationException("Channel pool has been disposed.")` whenever both the snapshot and the re-read of `_unhealthySignalCts.Token` threw ODE. In the (essentially-unreachable) case where two consecutive probe-success rotations fired during a single caller's snapshot/re-read window, the message was wrong — the pool wasn't disposed.

`DisposeAsync` sets `_disposed = 1` BEFORE disposing `_unhealthySignalCts`, so the flag is a reliable "this really is disposal" signal:

```csharp
throw Volatile.Read(ref _disposed) != 0
    ? new InvalidOperationException(POOL_DISPOSED_MESSAGE)
    : PoolExhaustedException();
```

## #316 — Testing hooks need `[Conditional]` / `#if DEBUG`

The original review suggested conditional compilation, but that doesn't fit this project — tests run in `Release` on CI per CLAUDE.md, so `#if DEBUG` would strip the methods at the wrong time. The strongest enforceable mitigation that survives Release builds is `[Obsolete(error: false)]` combined with the project-wide `TreatWarningsAsErrors`:

- Any new accidental in-src call fails the build (CS0618 → error).
- Test file suppresses CS0618 with a file-scope `#pragma warning disable CS0618`.

## #317 — `ChannelCount=1` probe-recovery test was missing

The `_size - 1` refill fix from PR #310 had a `ChannelCount = 1` edge case (refill cohort of zero, for loop never enters, post-loop `Warming → Open` CAS) that wasn't covered by the existing `ProbeRecovery_WithChannelCountGreaterThanOne_…` test (which uses `ChannelCount = 2`). New `ProbeRecovery_WithChannelCountOne_RefillCohortOfZeroReachesOpenState` mirrors the size-2 test and pins the size-1 path.

## Test plan

- [x] `dotnet build -c Release` clean across all TFMs
- [x] Full unit test suite: 162/162 (net10.0) and 161/161 (net8.0) — gained the new size-1 recovery test
- [x] `dotnet format --verify-no-changes --severity warn` clean
- [ ] Integration tests against `docker compose` brokers (not affected; smoke pass before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)