### PR TITLE
docs: add Trivy security scan badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![Publish preview to GitHub registry](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/publish-prerelease.yml/badge.svg)](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/publish-prerelease.yml)
 [![Publish release to Nuget registry](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/publish-release.yml/badge.svg)](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/publish-release.yml)
 [![CodeQL analysis](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/codeql-analysis.yml)
+[![Trivy security scan](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/trivy.yml/badge.svg)](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/trivy.yml)
 
 > A [Serilog](https://serilog.net/) sink that publishes log events to RabbitMQ via the
 > official [RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client) library.


### PR DESCRIPTION
Adds the Trivy security scan workflow status badge to the README badge row, next to CodeQL.

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)