### PR TITLE
docs: cache-bust the commits-since badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![Publish preview to GitHub registry](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/publish-prerelease.yml/badge.svg)](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/publish-prerelease.yml)
 [![Publish release to Nuget registry](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/publish-release.yml/badge.svg)](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/publish-release.yml)
 [![CodeQL analysis](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/codeql-analysis.yml)
+[![Trivy security scan](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/trivy.yml/badge.svg)](https://github.com/ArieGato/serilog-sinks-rabbitmq/actions/workflows/trivy.yml)
 
 > A [Serilog](https://serilog.net/) sink that publishes log events to RabbitMQ via the
 > official [RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client) library.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Nuget](https://img.shields.io/nuget/v/Serilog.Sinks.RabbitMQ)](https://www.nuget.org/packages/Serilog.Sinks.RabbitMQ)
 
 [![GitHub Release Date](https://img.shields.io/github/release-date/ArieGato/serilog-sinks-rabbitmq?label=released)](https://github.com/ArieGato/serilog-sinks-rabbitmq/releases)
-[![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/ArieGato/serilog-sinks-rabbitmq/latest?label=new+commits)](https://github.com/ArieGato/serilog-sinks-rabbitmq/commits/master)
+[![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/ArieGato/serilog-sinks-rabbitmq/latest?label=new+commits&cacheSeconds=1800)](https://github.com/ArieGato/serilog-sinks-rabbitmq/commits/master)
 ![Size](https://img.shields.io/github/repo-size/ArieGato/serilog-sinks-rabbitmq)
 
 [![GitHub contributors](https://img.shields.io/github/contributors/ArieGato/serilog-sinks-rabbitmq)](https://github.com/ArieGato/serilog-sinks-rabbitmq/graphs/contributors)


### PR DESCRIPTION
Appends `&cacheSeconds=1800` to the "new commits" shields badge so the URL changes (forcing GitHub's Camo image proxy to drop its stale/invalid cached SVG) and shields advertises a shorter cache TTL going forward.

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)