### PR TITLE
test: migrate xunit v2 to xunit.v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="System.Text.Json" Version="10.0.6" />
     <PackageVersion Include="System.Threading.Channels" Version="10.0.10" />
     <PackageVersion Include="Testcontainers.RabbitMq" Version="4.13.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/AuditToRabbitMQSinkAuditTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/AuditToRabbitMQSinkAuditTests.cs
@@ -36,7 +36,7 @@ public sealed class AuditToRabbitMQSinkAuditTests : IClassFixture<RabbitMQFixtur
     [Fact]
     public async Task Error_LogWithExceptionAndProperties_ConsumerReceivesMessage()
     {
-        await _rabbitMQFixture.InitializeAsync();
+        await _rabbitMQFixture.InitializeAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         const string messageTemplate = "Audit entry with {value}";
 
@@ -58,7 +58,7 @@ public sealed class AuditToRabbitMQSinkAuditTests : IClassFixture<RabbitMQFixtur
 
         logger.Information(messageTemplate, 1.0);
 
-        await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
 
         JObject? receivedMessage = null;
 

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/AuditToRabbitMQSinkAuditTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/AuditToRabbitMQSinkAuditTests.cs
@@ -68,11 +68,11 @@ public sealed class AuditToRabbitMQSinkAuditTests : IClassFixture<RabbitMQFixtur
             receivedMessage = JObject.Parse(Encoding.UTF8.GetString(eventArgs.Body.ToArray()));
             return Task.CompletedTask;
         };
-        await channel.BasicConsumeAsync(RabbitMQFixture.SerilogAuditSinkQueueName, autoAck: true, consumer);
+        await channel.BasicConsumeAsync(RabbitMQFixture.SerilogAuditSinkQueueName, autoAck: true, consumer, cancellationToken: TestContext.Current.CancellationToken);
         logger.Information(messageTemplate, 1.0);
 
         // Wait for consumer to receive the message.
-        await Task.Delay(200);
+        await Task.Delay(200, TestContext.Current.CancellationToken);
 
         receivedMessage.ShouldNotBeNull();
         receivedMessage["Level"].ShouldBe("Information");
@@ -80,7 +80,7 @@ public sealed class AuditToRabbitMQSinkAuditTests : IClassFixture<RabbitMQFixtur
         receivedMessage["Properties"].ShouldNotBeNull();
         ((double)receivedMessage["Properties"]!["value"]!).ShouldBe(1.0);
 
-        await channel.CloseAsync();
+        await channel.CloseAsync(TestContext.Current.CancellationToken);
         logger.Dispose();
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/ConfigurationExtensionsFixture.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/ConfigurationExtensionsFixture.cs
@@ -37,8 +37,8 @@ public class ConfigurationExtensionsFixture : IClassFixture<RabbitMQFixture>
             .CreateLogger();
 
         await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
-        await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-exchange");
-        await cleanupChannel.CloseAsync();
+        await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-exchange", cancellationToken: TestContext.Current.CancellationToken);
+        await cleanupChannel.CloseAsync(TestContext.Current.CancellationToken);
 
         // should not throw
         logger.Dispose();
@@ -52,8 +52,8 @@ public class ConfigurationExtensionsFixture : IClassFixture<RabbitMQFixture>
             .CreateLogger();
 
         await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
-        await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-exchange");
-        await cleanupChannel.CloseAsync();
+        await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-exchange", cancellationToken: TestContext.Current.CancellationToken);
+        await cleanupChannel.CloseAsync(TestContext.Current.CancellationToken);
 
         // should not throw
         logger.Dispose();
@@ -67,8 +67,8 @@ public class ConfigurationExtensionsFixture : IClassFixture<RabbitMQFixture>
             .CreateLogger();
 
         await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
-        await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-audit-exchange");
-        await cleanupChannel.CloseAsync();
+        await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-audit-exchange", cancellationToken: TestContext.Current.CancellationToken);
+        await cleanupChannel.CloseAsync(TestContext.Current.CancellationToken);
 
         // should not throw
         logger.Dispose();
@@ -282,7 +282,7 @@ public class ConfigurationExtensionsFixture : IClassFixture<RabbitMQFixture>
         // Actually log something to trigger the exchange creation
         logger.Information("Some text");
 
-        await Task.Delay(1000); // wait batch execution
+        await Task.Delay(1000, TestContext.Current.CancellationToken); // wait batch execution
 
         // should not throw
         logger.Dispose();

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/ConfigurationExtensionsFixture.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/ConfigurationExtensionsFixture.cs
@@ -36,7 +36,7 @@ public class ConfigurationExtensionsFixture : IClassFixture<RabbitMQFixture>
         var logger = loggerConfiguration.ReadFrom.AppSettings(settingPrefix: "W")
             .CreateLogger();
 
-        await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
         await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-exchange", cancellationToken: TestContext.Current.CancellationToken);
         await cleanupChannel.CloseAsync(TestContext.Current.CancellationToken);
 
@@ -51,7 +51,7 @@ public class ConfigurationExtensionsFixture : IClassFixture<RabbitMQFixture>
         var logger = loggerConfiguration.ReadFrom.AppSettings(settingPrefix: "H")
             .CreateLogger();
 
-        await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
         await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-exchange", cancellationToken: TestContext.Current.CancellationToken);
         await cleanupChannel.CloseAsync(TestContext.Current.CancellationToken);
 
@@ -66,7 +66,7 @@ public class ConfigurationExtensionsFixture : IClassFixture<RabbitMQFixture>
         var logger = loggerConfiguration.ReadFrom.AppSettings(settingPrefix: "A")
             .CreateLogger();
 
-        await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var cleanupChannel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
         await cleanupChannel.ExchangeDeleteAsync("serilog-settings-sink-audit-exchange", cancellationToken: TestContext.Current.CancellationToken);
         await cleanupChannel.CloseAsync(TestContext.Current.CancellationToken);
 

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/FallbackChainOutageTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/FallbackChainOutageTests.cs
@@ -17,7 +17,6 @@
 using Serilog.Debugging;
 using Serilog.Events;
 using Testcontainers.RabbitMq;
-using Xunit.Abstractions;
 
 namespace Serilog.Sinks.RabbitMQ.Tests.Integration;
 
@@ -44,9 +43,9 @@ public sealed class FallbackChainOutageTests : IAsyncLifetime
         _output = output;
     }
 
-    public Task InitializeAsync() => _container.StartAsync();
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
 
-    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
 
     [Theory]
     [InlineData(false)]
@@ -105,9 +104,9 @@ public sealed class FallbackChainOutageTests : IAsyncLifetime
 
             // Allow the warm-up batch to flush before killing the broker, so we know the
             // fallback file's contents come from POST-outage batches only.
-            await Task.Delay(750);
+            await Task.Delay(750, TestContext.Current.CancellationToken);
 
-            await _container.StopAsync();
+            await _container.StopAsync(TestContext.Current.CancellationToken);
 
             // Drive enough events that BatchPostingLimit (=5) triggers multiple batches.
             // Each batch's PublishAsync now fails (broker socket dead); EmitBatchAsync
@@ -127,13 +126,13 @@ public sealed class FallbackChainOutageTests : IAsyncLifetime
             logger.Dispose();
 
             // Allow the File sink to flush its writer before we read.
-            await Task.Delay(2000);
+            await Task.Delay(2000, TestContext.Current.CancellationToken);
 
             _output.WriteLine("SelfLog output:\n" + selfLog);
 
             System.IO.File.Exists(fallbackPath).ShouldBeTrue($"fallback file '{fallbackPath}' must exist after broker outage");
 
-            var lines = await System.IO.File.ReadAllLinesAsync(fallbackPath);
+            var lines = await System.IO.File.ReadAllLinesAsync(fallbackPath, TestContext.Current.CancellationToken);
             _output.WriteLine($"fallback file line count: {lines.Length}");
             foreach (var line in lines.Take(5))
             {

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMQFixture.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMQFixture.cs
@@ -84,50 +84,50 @@ public class RabbitMQFixture : IAsyncDisposable
             },
         };
 
-    public async Task InitializeAsync(string? exchangeName = null)
+    public async Task InitializeAsync(string? exchangeName = null, CancellationToken cancellationToken = default)
     {
         // Initialize the exchanges and queues.
-        await using var channel = await GetConsumingChannelAsync();
+        await using var channel = await GetConsumingChannelAsync(cancellationToken);
 
-        await channel.ExchangeDeclareAsync(SerilogSinkExchange, SerilogSinkExchangeType, true);
-        await channel.QueueDeclareAsync(SerilogSinkQueueName, true, false, false);
-        await channel.QueueBindAsync(SerilogSinkQueueName, SerilogSinkExchange, string.Empty);
+        await channel.ExchangeDeclareAsync(SerilogSinkExchange, SerilogSinkExchangeType, true, cancellationToken: cancellationToken);
+        await channel.QueueDeclareAsync(SerilogSinkQueueName, true, false, false, cancellationToken: cancellationToken);
+        await channel.QueueBindAsync(SerilogSinkQueueName, SerilogSinkExchange, string.Empty, cancellationToken: cancellationToken);
 
-        await channel.ExchangeDeclareAsync(SerilogAuditSinkExchange, SerilogAuditSinkExchangeType, true);
-        await channel.QueueDeclareAsync(SerilogAuditSinkQueueName, true, false, false);
-        await channel.QueueBindAsync(SerilogAuditSinkQueueName, SerilogAuditSinkExchange, string.Empty);
+        await channel.ExchangeDeclareAsync(SerilogAuditSinkExchange, SerilogAuditSinkExchangeType, true, cancellationToken: cancellationToken);
+        await channel.QueueDeclareAsync(SerilogAuditSinkQueueName, true, false, false, cancellationToken: cancellationToken);
+        await channel.QueueBindAsync(SerilogAuditSinkQueueName, SerilogAuditSinkExchange, string.Empty, cancellationToken: cancellationToken);
 
         if (!string.IsNullOrEmpty(exchangeName))
         {
-            await channel.ExchangeDeclareAsync(exchangeName!, SerilogSinkExchangeType, true);
+            await channel.ExchangeDeclareAsync(exchangeName!, SerilogSinkExchangeType, true, cancellationToken: cancellationToken);
         }
 
-        await channel.CloseAsync();
+        await channel.CloseAsync(cancellationToken);
 
-        await Task.Delay(500);
+        await Task.Delay(500, cancellationToken);
     }
 
-    public async ValueTask DisposeAsync() => await CleanupAsync();
+    public async ValueTask DisposeAsync() => await CleanupAsync(TestContext.Current.CancellationToken);
 
-    public async Task CleanupAsync()
+    public async Task CleanupAsync(CancellationToken cancellationToken = default)
     {
         // Always cleanup the exchanges and queues.
-        _consumingConnection ??= await _connectionFactory.CreateConnectionAsync();
+        _consumingConnection ??= await _connectionFactory.CreateConnectionAsync(cancellationToken);
 
-        var channel = await _consumingConnection.CreateChannelAsync();
+        var channel = await _consumingConnection.CreateChannelAsync(cancellationToken: cancellationToken);
 
-        await channel.QueueDeleteAsync(SerilogSinkQueueName);
-        await channel.ExchangeDeleteAsync(SerilogSinkExchange);
+        await channel.QueueDeleteAsync(SerilogSinkQueueName, cancellationToken: cancellationToken);
+        await channel.ExchangeDeleteAsync(SerilogSinkExchange, cancellationToken: cancellationToken);
 
-        await channel.QueueDeleteAsync(SerilogAuditSinkQueueName);
-        await channel.ExchangeDeleteAsync(SerilogAuditSinkExchange);
+        await channel.QueueDeleteAsync(SerilogAuditSinkQueueName, cancellationToken: cancellationToken);
+        await channel.ExchangeDeleteAsync(SerilogAuditSinkExchange, cancellationToken: cancellationToken);
 
-        await channel.CloseAsync();
+        await channel.CloseAsync(cancellationToken);
         channel.Dispose();
 
         if (_consumingConnection is not null)
         {
-            await _consumingConnection.CloseAsync();
+            await _consumingConnection.CloseAsync(cancellationToken);
         }
 
         _consumingConnection?.Dispose();
@@ -138,15 +138,15 @@ public class RabbitMQFixture : IAsyncDisposable
     public Task PublishAsync(string message) => _rabbitMQClient.PublishAsync(Encoding.UTF8.GetBytes(message), new BasicProperties());
 
     // The IChannel is not disposed automatically, so the calling member is responsible for disposing it.
-    public async Task<IChannel> GetConsumingChannelAsync()
+    public async Task<IChannel> GetConsumingChannelAsync(CancellationToken cancellationToken = default)
     {
         int counter = 0;
         while (true)
         {
             try
             {
-                _consumingConnection ??= await _connectionFactory.CreateConnectionAsync();
-                return await _consumingConnection.CreateChannelAsync();
+                _consumingConnection ??= await _connectionFactory.CreateConnectionAsync(cancellationToken);
+                return await _consumingConnection.CreateChannelAsync(cancellationToken: cancellationToken);
             }
             catch (BrokerUnreachableException)
             {
@@ -155,7 +155,7 @@ public class RabbitMQFixture : IAsyncDisposable
                     throw new Exception("Failed to connect to RabbitMQ.");
                 }
 
-                await Task.Delay(1000);
+                await Task.Delay(1000, cancellationToken);
             }
         }
     }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMQFixture.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMQFixture.cs
@@ -17,7 +17,7 @@ using System.Security.Authentication;
 
 namespace Serilog.Sinks.RabbitMQ.Tests.Integration;
 
-public class RabbitMQFixture : IDisposable
+public class RabbitMQFixture : IAsyncDisposable
 {
     public const string UserName = "serilog";
     public const string Password = "serilog";
@@ -107,7 +107,7 @@ public class RabbitMQFixture : IDisposable
         await Task.Delay(500);
     }
 
-    public void Dispose() => AsyncHelpers.RunSync(CleanupAsync);
+    public async ValueTask DisposeAsync() => await CleanupAsync();
 
     public async Task CleanupAsync()
     {

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTests.cs
@@ -49,15 +49,15 @@ public sealed class RabbitMQClientTests : IClassFixture<RabbitMQFixture>
             return Task.CompletedTask;
         };
 
-        await consumingChannel.BasicConsumeAsync(RabbitMQFixture.SerilogSinkQueueName, autoAck: true, consumer);
+        await consumingChannel.BasicConsumeAsync(RabbitMQFixture.SerilogSinkQueueName, autoAck: true, consumer, cancellationToken: TestContext.Current.CancellationToken);
         await _rabbitMQFixture.PublishAsync(message);
 
         // Wait for consumer to receive the message.
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         receivedMessage.ShouldBe(message);
 
-        await consumingChannel.CloseAsync();
+        await consumingChannel.CloseAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public sealed class RabbitMQClientTests : IClassFixture<RabbitMQFixture>
         };
 
         // start consuming queue
-        await consumingChannel.BasicConsumeAsync(RabbitMQFixture.SerilogSinkQueueName, autoAck: true, consumer);
+        await consumingChannel.BasicConsumeAsync(RabbitMQFixture.SerilogSinkQueueName, autoAck: true, consumer, cancellationToken: TestContext.Current.CancellationToken);
 
         for (int i = 0; i < 100; i++)
         {
@@ -91,11 +91,11 @@ public sealed class RabbitMQClientTests : IClassFixture<RabbitMQFixture>
         }
 
         // Wait for consumer to receive the message.
-        await Task.Delay(1000);
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
 
         receivedMessage.ShouldBe(message);
 
-        await consumingChannel.CloseAsync();
+        await consumingChannel.CloseAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -117,20 +117,20 @@ public sealed class RabbitMQClientTests : IClassFixture<RabbitMQFixture>
         await rabbitMQClient.PublishAsync("a message"u8.ToArray(), new BasicProperties());
 
         //// wait for message sent
-        // await Task.Delay(1000);
+        // await Task.Delay(1000, TestContext.Current.CancellationToken);
         await using var consumingChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
 
         try
         {
             // should not throw
-            await consumingChannel.ExchangeDeclarePassiveAsync("auto-created-exchange-name");
+            await consumingChannel.ExchangeDeclarePassiveAsync("auto-created-exchange-name", cancellationToken: TestContext.Current.CancellationToken);
         }
         finally
         {
-            await consumingChannel.ExchangeDeleteAsync("auto-created-exchange-name");
+            await consumingChannel.ExchangeDeleteAsync("auto-created-exchange-name", cancellationToken: TestContext.Current.CancellationToken);
         }
 
-        await consumingChannel.CloseAsync();
+        await consumingChannel.CloseAsync(TestContext.Current.CancellationToken);
         await rabbitMQClient.CloseAsync();
     }
 
@@ -167,7 +167,7 @@ public sealed class RabbitMQClientTests : IClassFixture<RabbitMQFixture>
         });
 
         // Add some delay to ensure all messages are published before the exchange is deleted
-        await Task.Delay(1000);
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
 
         await rabbitMQClient.CloseAsync();
     }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTests.cs
@@ -34,11 +34,11 @@ public sealed class RabbitMQClientTests : IClassFixture<RabbitMQFixture>
     [Fact]
     public async Task Publish_SingleMessage_ConsumerReceivesMessage()
     {
-        await _rabbitMQFixture.InitializeAsync();
+        await _rabbitMQFixture.InitializeAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         string message = Guid.NewGuid().ToString();
 
-        await using var consumingChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var consumingChannel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
 
         string? receivedMessage = null;
 
@@ -67,11 +67,11 @@ public sealed class RabbitMQClientTests : IClassFixture<RabbitMQFixture>
     [Fact]
     public async Task Publish_BulkMessages_ConsumerReceivesMessage()
     {
-        await _rabbitMQFixture.InitializeAsync();
+        await _rabbitMQFixture.InitializeAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         string message = Guid.NewGuid().ToString();
 
-        await using var consumingChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var consumingChannel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
 
         string? receivedMessage = null;
 
@@ -118,7 +118,7 @@ public sealed class RabbitMQClientTests : IClassFixture<RabbitMQFixture>
 
         //// wait for message sent
         // await Task.Delay(1000, TestContext.Current.CancellationToken);
-        await using var consumingChannel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var consumingChannel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
 
         try
         {

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/Serilog.Sinks.RabbitMQ.Tests.Integration.csproj
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/Serilog.Sinks.RabbitMQ.Tests.Integration.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +14,7 @@
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="coverlet.msbuild" PrivateAssets="all" />
     <PackageReference Include="Shouldly" />

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTests.cs
@@ -68,11 +68,11 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
             return Task.CompletedTask;
         };
 
-        await channel.BasicConsumeAsync(RabbitMQFixture.SerilogSinkQueueName, autoAck: true, consumer);
+        await channel.BasicConsumeAsync(RabbitMQFixture.SerilogSinkQueueName, autoAck: true, consumer, cancellationToken: TestContext.Current.CancellationToken);
         logger.Error(new DivideByZeroException(), messageTemplate, 1.0, 0.0);
 
         // Wait for consumer to receive the message.
-        await Task.Delay(1000);
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
 
         try
         {
@@ -89,7 +89,7 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
             Assert.Fail(e.Message + " " + receivedMessage);
         }
 
-        await channel.CloseAsync();
+        await channel.CloseAsync(TestContext.Current.CancellationToken);
     }
 
     /// <summary>
@@ -122,11 +122,11 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
             return Task.CompletedTask;
         };
 
-        await channel.BasicConsumeAsync(RabbitMQFixture.SerilogSinkQueueName, autoAck: true, consumer);
+        await channel.BasicConsumeAsync(RabbitMQFixture.SerilogSinkQueueName, autoAck: true, consumer, cancellationToken: TestContext.Current.CancellationToken);
         logger.Debug(messageTemplate);
 
         // Wait for consumer to receive the message.
-        await Task.Delay(1000);
+        await Task.Delay(1000, TestContext.Current.CancellationToken);
 
         try
         {
@@ -139,7 +139,7 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
             Assert.Fail(e.Message + " " + receivedMessage);
         }
 
-        await channel.CloseAsync();
+        await channel.CloseAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -150,9 +150,9 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
 
         await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync();
 
-        await channel.ExchangeDeclareAsync(logParallelMessageExchange, RabbitMQFixture.SerilogSinkExchangeType, true);
-        await channel.QueueDeclareAsync(logParallelMessageQueue, true, false, false);
-        await channel.QueueBindAsync(logParallelMessageQueue, logParallelMessageExchange, string.Empty);
+        await channel.ExchangeDeclareAsync(logParallelMessageExchange, RabbitMQFixture.SerilogSinkExchangeType, true, cancellationToken: TestContext.Current.CancellationToken);
+        await channel.QueueDeclareAsync(logParallelMessageQueue, true, false, false, cancellationToken: TestContext.Current.CancellationToken);
+        await channel.QueueBindAsync(logParallelMessageQueue, logParallelMessageExchange, string.Empty, cancellationToken: TestContext.Current.CancellationToken);
 
         var config = new RabbitMQClientConfiguration
         {
@@ -195,18 +195,18 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
             }
         });
 
-        while (await channel.MessageCountAsync(logParallelMessageQueue) < 10000)
+        while (await channel.MessageCountAsync(logParallelMessageQueue, cancellationToken: TestContext.Current.CancellationToken) < 10000)
         {
             if (watch.ElapsedMilliseconds > 10000)
             {
                 Assert.Fail("Timeout waiting for messages to be published. Maybe messages are lost");
             }
 
-            await Task.Delay(200);
+            await Task.Delay(200, TestContext.Current.CancellationToken);
         }
 
         watch.Stop();
 
-        await channel.CloseAsync();
+        await channel.CloseAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/WriteToRabbitMQSinkTests.cs
@@ -38,7 +38,7 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
     [Fact]
     public async Task Error_LogWithExceptionAndProperties_ConsumerReceivesMessage()
     {
-        await _rabbitMQFixture.InitializeAsync();
+        await _rabbitMQFixture.InitializeAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         using var logger = new LoggerConfiguration()
             .WriteTo.RabbitMQ((clientConfiguration, sinkConfiguration) =>
@@ -57,7 +57,7 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
 
         const string messageTemplate = "Denominator cannot be zero in {numerator}/{denominator}";
 
-        await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
 
         JObject? receivedMessage = null;
 
@@ -99,7 +99,7 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
     [Fact]
     public async Task Debug_ThroughReadConfiguration_ConsumerReceivesMessage()
     {
-        await _rabbitMQFixture.InitializeAsync();
+        await _rabbitMQFixture.InitializeAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.without.levelswitch.json", false, true)
@@ -111,7 +111,7 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
 
         const string messageTemplate = "This is a debug log message";
 
-        await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
 
         JObject? receivedMessage = null;
 
@@ -148,7 +148,7 @@ public sealed class WriteToRabbitMQSinkTests : IClassFixture<RabbitMQFixture>
         const string logParallelMessageExchange = "log-parallel-message-exchange";
         const string logParallelMessageQueue = "log-parallel-message-queue";
 
-        await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync();
+        await using var channel = await _rabbitMQFixture.GetConsumingChannelAsync(TestContext.Current.CancellationToken);
 
         await channel.ExchangeDeclareAsync(logParallelMessageExchange, RabbitMQFixture.SerilogSinkExchangeType, true, cancellationToken: TestContext.Current.CancellationToken);
         await channel.QueueDeclareAsync(logParallelMessageQueue, true, false, false, cancellationToken: TestContext.Current.CancellationToken);

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelPoolTests.cs
@@ -105,7 +105,7 @@ public class RabbitMQChannelPoolTests
         await WaitForAsync(() => Volatile.Read(ref created) == 2);
 
         // Act
-        var channel = await pool.GetAsync();
+        var channel = await pool.GetAsync(TestContext.Current.CancellationToken);
 
         // Assert
         channel.ShouldNotBeNull();
@@ -121,11 +121,11 @@ public class RabbitMQChannelPoolTests
         var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
 
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        var first = await pool.GetAsync();
+        var first = await pool.GetAsync(TestContext.Current.CancellationToken);
 
         // Act
-        var pending = pool.GetAsync().AsTask();
-        await Task.Delay(50);
+        var pending = pool.GetAsync(TestContext.Current.CancellationToken).AsTask();
+        await Task.Delay(50, TestContext.Current.CancellationToken);
         pending.IsCompleted.ShouldBeFalse();
 
         await pool.ReturnAsync(first);
@@ -149,7 +149,7 @@ public class RabbitMQChannelPoolTests
         var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
 
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        _ = await pool.GetAsync();
+        _ = await pool.GetAsync(TestContext.Current.CancellationToken);
 
         var brokenChannel = Substitute.For<IRabbitMQChannel>();
         brokenChannel.IsOpen.Returns(false);
@@ -184,7 +184,7 @@ public class RabbitMQChannelPoolTests
         var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
 
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        _ = await pool.GetAsync();
+        _ = await pool.GetAsync(TestContext.Current.CancellationToken);
 
         var brokenChannel = Substitute.For<IRabbitMQChannel>();
         brokenChannel.IsOpen.Returns(false);
@@ -208,7 +208,7 @@ public class RabbitMQChannelPoolTests
         var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
 
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        _ = await pool.GetAsync();
+        _ = await pool.GetAsync(TestContext.Current.CancellationToken);
 
         using var cts = new CancellationTokenSource();
 
@@ -259,7 +259,7 @@ public class RabbitMQChannelPoolTests
 
         // Rent the warmed-up channel first so the substituted throwing channel can be
         // returned without overflowing the pool's SemaphoreSlim (capped at ChannelCount).
-        _ = await pool.GetAsync();
+        _ = await pool.GetAsync(TestContext.Current.CancellationToken);
 
         var throwingChannel = Substitute.For<IRabbitMQChannel>();
         throwingChannel.IsOpen.Returns(true);
@@ -304,7 +304,7 @@ public class RabbitMQChannelPoolTests
             }
         });
 
-        _ = await pool.GetAsync();
+        _ = await pool.GetAsync(TestContext.Current.CancellationToken);
 
         var brokenChannel = Substitute.For<IRabbitMQChannel>();
         brokenChannel.IsOpen.Returns(false);
@@ -410,7 +410,7 @@ public class RabbitMQChannelPoolTests
         // release the gate, otherwise the flag will already be set by the first warmup
         // and the race will not fire (false green). 500 ms is generous for slow CI
         // workers; this happens on every run so the cost is bounded.
-        await Task.Delay(500);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
 
         gate.SetResult(true);
 
@@ -488,7 +488,7 @@ public class RabbitMQChannelPoolTests
         await WaitForAsync(() => failedChannel.ReceivedCalls()
             .Any(call => call.GetMethodInfo().Name == nameof(IChannel.CloseAsync)));
 
-        await failedChannel.Received().CloseAsync();
+        await failedChannel.Received().CloseAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -618,13 +618,13 @@ public class RabbitMQChannelPoolTests
         // Dispose the pool: _shutdownCts cancels the warm-up's token. The declare call
         // becomes cancelled (TrySetCanceled propagates via the task), the catch fires,
         // and the channel must be closed.
-        declareGate.TrySetCanceled();
+        declareGate.TrySetCanceled(TestContext.Current.CancellationToken);
         await pool.DisposeAsync();
 
         await WaitForAsync(() => blockedChannel.ReceivedCalls()
             .Any(call => call.GetMethodInfo().Name == nameof(IChannel.CloseAsync)));
 
-        await blockedChannel.Received().CloseAsync();
+        await blockedChannel.Received().CloseAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -643,7 +643,7 @@ public class RabbitMQChannelPoolTests
 
         await pool.DisposeAsync();
 
-        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -661,7 +661,7 @@ public class RabbitMQChannelPoolTests
 
         // Drain+return the warmed channel to guarantee the pool is at capacity before
         // we test the surplus path. Just waiting on ReceivedCalls races with the write.
-        var warmed = await pool.GetAsync();
+        var warmed = await pool.GetAsync(TestContext.Current.CancellationToken);
         await pool.ReturnAsync(warmed);
 
         var surplusChannel = Substitute.For<IRabbitMQChannel>();
@@ -685,7 +685,7 @@ public class RabbitMQChannelPoolTests
 
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
 
-        var warmed = await pool.GetAsync();
+        var warmed = await pool.GetAsync(TestContext.Current.CancellationToken);
         await pool.ReturnAsync(warmed);
 
         var surplusChannel = Substitute.For<IRabbitMQChannel>();
@@ -792,7 +792,7 @@ public class RabbitMQChannelPoolTests
 
         // Act
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        var channel = await pool.GetAsync();
+        var channel = await pool.GetAsync(TestContext.Current.CancellationToken);
 
         // Assert
         channel.ShouldNotBeNull();
@@ -818,7 +818,7 @@ public class RabbitMQChannelPoolTests
         var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
 
         var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act + Assert
         await Should.NotThrowAsync(async () => await pool.DisposeAsync());
@@ -836,7 +836,7 @@ public class RabbitMQChannelPoolTests
         var configuration = new RabbitMQClientConfiguration { ChannelCount = 1 };
 
         var pool = new RabbitMQChannelPool(configuration, connectionFactory);
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act + Assert
         await Should.NotThrowAsync(async () => await pool.DisposeAsync());
@@ -897,7 +897,7 @@ public class RabbitMQChannelPoolTests
         declareGate.SetResult(true);
 
         // Task.WaitAsync(TimeSpan) is .NET 6+; use Task.WhenAny for net48 compatibility.
-        var completed = await Task.WhenAny(disposed.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+        var completed = await Task.WhenAny(disposed.Task, Task.Delay(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
         completed.ShouldBeSameAs(disposed.Task, "warm-up did not reach the orphan-dispose path within the timeout");
         await disposed.Task;
 
@@ -978,7 +978,7 @@ public class RabbitMQChannelPoolTests
 
         await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync(TestContext.Current.CancellationToken));
         ex.Message.ShouldContain("exhausted");
         ex.Message.ShouldContain("2");
     }
@@ -1020,7 +1020,7 @@ public class RabbitMQChannelPoolTests
 
         // The probe succeeds, the caller falls through to ReadAsync, and the refill task
         // eventually takes state back to Open.
-        var channel = await pool.GetAsync();
+        var channel = await pool.GetAsync(TestContext.Current.CancellationToken);
         channel.ShouldNotBeNull();
 
         await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
@@ -1055,14 +1055,14 @@ public class RabbitMQChannelPoolTests
         ExpireCooldown(pool);
 
         // First post-cooldown call triggers the probe. Probe fails → back to Broken.
-        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync(TestContext.Current.CancellationToken));
         pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Broken);
 
         // Probe used exactly one attempt on top of the pre-cooldown budget.
         Volatile.Read(ref attempts).ShouldBe(attemptsAfterExhaustion + 1);
 
         // Second post-cooldown call finds a FRESH cooldown and throws without probing.
-        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync(TestContext.Current.CancellationToken));
         Volatile.Read(ref attempts).ShouldBe(attemptsAfterExhaustion + 1);
     }
 
@@ -1107,7 +1107,7 @@ public class RabbitMQChannelPoolTests
         {
             try
             {
-                return await pool.GetAsync();
+                return await pool.GetAsync(TestContext.Current.CancellationToken);
             }
             catch (InvalidOperationException)
             {
@@ -1169,7 +1169,7 @@ public class RabbitMQChannelPoolTests
         await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Broken);
         ExpireCooldown(pool);
 
-        var probeCall = pool.GetAsync().AsTask();
+        var probeCall = pool.GetAsync(TestContext.Current.CancellationToken).AsTask();
 
         // Wait until the probe has entered CreateChannelAsync (attempt 3).
         await WaitForAsync(() => Volatile.Read(ref attempts) >= 3);
@@ -1292,7 +1292,7 @@ public class RabbitMQChannelPoolTests
 
         // Park a caller on ReadAsync BEFORE the pool has had time to reach Broken.
         // Pool is Warming; pool is empty; caller blocks.
-        var waiter = pool.GetAsync().AsTask();
+        var waiter = pool.GetAsync(TestContext.Current.CancellationToken).AsTask();
         pool.CurrentState.ShouldNotBe(RabbitMQChannelPool.PoolState.Broken);
 
         // Wait for warm-up to exhaust — this fires SignalUnhealthy after flipping state.
@@ -1424,7 +1424,7 @@ public class RabbitMQChannelPoolTests
         await WaitForAsync(() => Volatile.Read(ref attempts) >= 1 + configuration.WarmUpMaxRetries!.Value);
 
         // Give the exhaustion block a beat to run its CAS pair + guarded SignalUnhealthy.
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // State must still be Probing (both CAS no-op'd) and the signal must NOT have fired.
         pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Probing);
@@ -1464,7 +1464,7 @@ public class RabbitMQChannelPoolTests
         await pool.ReturnAsync(brokenChannel);
 
         // Give the refill task time to have run if it were going to.
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
         Volatile.Read(ref attempts).ShouldBe(attemptsAfterExhaustion);
         pool.CurrentState.ShouldBe(RabbitMQChannelPool.PoolState.Broken);
@@ -1516,7 +1516,7 @@ public class RabbitMQChannelPoolTests
         await WaitForAsync(() => Volatile.Read(ref created) > createdBeforeReturn);
 
         // Allow the cohort-completion block (including the gated reset) to run.
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // The opportunistic refill must NOT have reset the counter.
         var failuresAfter = (int)(failuresField.GetValue(pool) ?? throw new InvalidOperationException("_consecutiveFailures value was null."));
@@ -1563,7 +1563,7 @@ public class RabbitMQChannelPoolTests
         await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
 
         // Drain the pool so GetAsync would normally park on ReadAsync.
-        await pool.GetAsync();
+        await pool.GetAsync(TestContext.Current.CancellationToken);
 
         // Complete the writer in place, without setting _disposed. GetAsync's fast
         // path sees _disposed == 0 and falls through to ReadAsync, which throws
@@ -1574,7 +1574,7 @@ public class RabbitMQChannelPoolTests
             ?? throw new InvalidOperationException("_channels value was null.");
         channels.Writer.TryComplete();
 
-        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync());
+        var ex = await Should.ThrowAsync<InvalidOperationException>(async () => await pool.GetAsync(TestContext.Current.CancellationToken));
         ex.Message.ShouldContain("disposed");
 
         // Pool field state is intentionally inconsistent post-test — no DisposeAsync
@@ -1595,11 +1595,11 @@ public class RabbitMQChannelPoolTests
         var pool = new RabbitMQChannelPool(configuration, connectionFactory);
 
         await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
-        await pool.GetAsync(); // drain
+        await pool.GetAsync(TestContext.Current.CancellationToken); // drain
 
         using var cts = new CancellationTokenSource();
         var parked = pool.GetAsync(cts.Token).AsTask();
-        await Task.Delay(50); // let parked call reach ReadAsync
+        await Task.Delay(50, TestContext.Current.CancellationToken); // let parked call reach ReadAsync
 
         // Flip _disposed without running the real DisposeAsync. The when-filter in
         // GetAsync's catch re-reads this field when the OCE fires, and must see it
@@ -1631,10 +1631,10 @@ public class RabbitMQChannelPoolTests
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
 
         await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
-        await pool.GetAsync(); // drain so GetAsync parks on ReadAsync
+        await pool.GetAsync(TestContext.Current.CancellationToken); // drain so GetAsync parks on ReadAsync
 
-        var parked = pool.GetAsync().AsTask();
-        await Task.Delay(50);
+        var parked = pool.GetAsync(TestContext.Current.CancellationToken).AsTask();
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Cancel the unhealthy CTS WITHOUT transitioning state.
         var ctsField = typeof(RabbitMQChannelPool).GetField("_unhealthySignalCts", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -1694,7 +1694,7 @@ public class RabbitMQChannelPoolTests
         await using var pool = new RabbitMQChannelPool(configuration, connectionFactory);
 
         await WaitForAsync(() => pool.CurrentState == RabbitMQChannelPool.PoolState.Open);
-        await pool.GetAsync(); // drain so a follow-on GetAsync would park on ReadAsync
+        await pool.GetAsync(TestContext.Current.CancellationToken); // drain so a follow-on GetAsync would park on ReadAsync
 
         var ctsField = typeof(RabbitMQChannelPool).GetField("_unhealthySignalCts", BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new InvalidOperationException("_unhealthySignalCts field not found.");
@@ -1785,8 +1785,8 @@ public class RabbitMQChannelPoolTests
         // mirrors the production post-outage state where the pool is exhausted
         // before the breaker trips. Without draining, the probe's TryWrite fails
         // on a full queue and the success path is never reached.
-        await pool.GetAsync();
-        await pool.GetAsync();
+        await pool.GetAsync(TestContext.Current.CancellationToken);
+        await pool.GetAsync(TestContext.Current.CancellationToken);
 
         // Force the pool into Broken with cooldown elapsed, mirroring the post-outage
         // state that HandleBrokenStateAsync's success path acts on.
@@ -1796,7 +1796,7 @@ public class RabbitMQChannelPoolTests
         // Run the probe directly. It writes 1 channel and spawns refill in the
         // background; we don't drain afterwards, so refill faces a pool that
         // already has 1/_size occupied — the exact race the bug exposes.
-        await pool.TestingInvokeHandleBrokenStateAsync(RabbitMQChannelPool.PoolState.Broken, default);
+        await pool.TestingInvokeHandleBrokenStateAsync(RabbitMQChannelPool.PoolState.Broken, TestContext.Current.CancellationToken);
 
         // With the bug present this WaitForAsync times out: refill orphans the (_size)th
         // channel, returns false from WarmUpSingleAsync, and exits before reaching the
@@ -1830,12 +1830,12 @@ public class RabbitMQChannelPoolTests
 
         // Drain so probe writes into an empty queue — same approach as the
         // ChannelCount > 1 sibling test.
-        await pool.GetAsync();
+        await pool.GetAsync(TestContext.Current.CancellationToken);
 
         pool.TestingSetState(RabbitMQChannelPool.PoolState.Broken);
         ExpireCooldown(pool);
 
-        await pool.TestingInvokeHandleBrokenStateAsync(RabbitMQChannelPool.PoolState.Broken, default);
+        await pool.TestingInvokeHandleBrokenStateAsync(RabbitMQChannelPool.PoolState.Broken, TestContext.Current.CancellationToken);
 
         await WaitForAsync(
             () => pool.CurrentState == RabbitMQChannelPool.PoolState.Open,

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQ/RabbitMQChannelTests.cs
@@ -30,7 +30,7 @@ public class RabbitMQChannelTests
         await sut.DisposeAsync();
 
         // Assert
-        await channel.Received(1).CloseAsync();
+        await channel.Received(1).CloseAsync(Arg.Any<CancellationToken>());
         channel.Received(1).Dispose();
     }
 
@@ -67,6 +67,6 @@ public class RabbitMQChannelTests
 
         // Assert
         var actual = Arg.Is<BasicProperties>(p => p!.AppId == basicProperties.AppId);
-        await channel.Received(1).BasicPublishAsync(address, actual, body);
+        await channel.Received(1).BasicPublishAsync(address, actual, body, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQConnectionFactoryTests.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/RabbitMQConnectionFactoryTests.cs
@@ -285,7 +285,7 @@ public class RabbitMQConnectionFactoryTests
 
         await sut.CloseAsync();
 
-        await connection.Received(1).CloseAsync();
+        await connection.Received(1).CloseAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -330,7 +330,7 @@ public class RabbitMQConnectionFactoryTests
         // than the regression guard.
         await sut.CloseAsync();
         semaphore.CurrentCount.ShouldBe(1);
-        await connection.Received(2).CloseAsync();
+        await connection.Received(2).CloseAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -343,7 +343,7 @@ public class RabbitMQConnectionFactoryTests
 
         await sut.DisposeAsync();
 
-        await connection.Received(1).CloseAsync();
+        await connection.Received(1).CloseAsync(Arg.Any<CancellationToken>());
         connection.Received(1).Dispose();
     }
 

--- a/tests/Serilog.Sinks.RabbitMQ.Tests/Serilog.Sinks.RabbitMQ.Tests.csproj
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests/Serilog.Sinks.RabbitMQ.Tests.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="PublicApiGenerator" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="coverlet.msbuild" PrivateAssets="all" />
     <PackageReference Include="Shouldly" />


### PR DESCRIPTION
## What

Replaces the deprecated `xunit` v2 package with **`xunit.v3` 3.2.2** across both test projects. Renovate flagged `xunit` as deprecated on the dependency dashboard (#345).

## Changes

- **[Directory.Packages.props]** — `xunit` 2.9.3 → `xunit.v3` 3.2.2. `xunit.runner.visualstudio` 3.1.5 and `Microsoft.NET.Test.Sdk` 18.8.1 already support v3.
- **Both test csprojs** — add `<OutputType>Exe</OutputType>` (v3 test projects are self-executing) and swap the package reference.
- **v3 breaking-change fixups:**
  - `FallbackChainOutageTests` — drop `using Xunit.Abstractions;` (namespace removed; `ITestOutputHelper` now lives in `Xunit`) and convert `IAsyncLifetime` members `Task` → `ValueTask`.
  - **xUnit1051** (a hard error under `TreatWarningsAsErrors`) resolved on every awaited call that accepts a `CancellationToken`:
    - Real calls under test (broker ops, `Task.Delay`, `File`, SUT) now pass `TestContext.Current.CancellationToken`. Broker `IChannel.*Async` calls use the **named** `cancellationToken:` argument because they have optional parameters before the token.
    - NSubstitute `.Received()` verifications use `Arg.Any<CancellationToken>()` so the assertion is not over-constrained.
  - `RabbitMQFixture` — switch from `IDisposable` + `AsyncHelpers.RunSync` to `IAsyncDisposable`. v3 surfaced the sync-over-async teardown as a `Test Class Cleanup Failure`; async disposal resolves it and removes a `RunSync` the guidelines warn against.

## Notes

- **Public API unchanged** — `ApiApprovalTests` green; `xunit.v3` is a dev-only dependency, so no CHANGELOG/README entry is warranted.
- No `src/` changes → no coverage impact.

## Verification

- Builds clean: **net8.0 / net10.0 / net48** (both test projects)
- Unit tests pass: **163** (net10.0), **162** (net8.0)
- Integration tests pass: **28** (net10.0), no cleanup failures
- `dotnet format --verify-no-changes --severity warn` clean

Refs #345 — addresses the `xunit` deprecation item on the Renovate dependency dashboard (the dashboard is an ongoing issue and should stay open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)